### PR TITLE
feat: add reservation page with Cal.com embed

### DIFF
--- a/src/app/reservation/reservation.module.css
+++ b/src/app/reservation/reservation.module.css
@@ -1,0 +1,102 @@
+.page {
+  min-height: 100vh;
+  background: var(--ryokan-bg);
+}
+
+.main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 120px 24px 96px;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.en {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--ryokan-gold);
+  font-family: var(--font-sans-jp);
+}
+
+.title {
+  margin: 10px 0 12px;
+  font-size: clamp(34px, 4vw, 44px);
+  font-weight: 500;
+  color: var(--ryokan-dark);
+  letter-spacing: 0.08em;
+  font-family: var(--font-serif-jp);
+}
+
+.lead {
+  margin: 0;
+  color: var(--ryokan-muted);
+  font-size: 14px;
+  line-height: 1.8;
+  letter-spacing: 0.03em;
+}
+
+.calendarSection {
+  margin-top: 36px;
+}
+
+.errorBox {
+  border: 1px solid rgba(139, 105, 20, 0.3);
+  border-radius: 12px;
+  background: #fff;
+  padding: 24px;
+  color: var(--ryokan-muted);
+}
+
+.errorBox h2 {
+  margin: 0 0 10px;
+  font-size: 20px;
+  font-weight: 500;
+  color: var(--ryokan-dark);
+}
+
+.errorBox p {
+  margin: 0 0 8px;
+  line-height: 1.8;
+}
+
+.contactRow {
+  margin-top: 30px;
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  align-items: center;
+  color: var(--ryokan-muted);
+  font-size: 14px;
+}
+
+.contactRow p {
+  margin: 0;
+}
+
+.contactRow a {
+  color: var(--ryokan-gold);
+  text-decoration: none;
+  font-family: var(--font-display);
+  font-size: 20px;
+  letter-spacing: 0.06em;
+}
+
+@media (max-width: 768px) {
+  .main {
+    padding: 98px 16px 72px;
+  }
+
+  .lead {
+    font-size: 13px;
+  }
+
+  .contactRow {
+    flex-direction: column;
+    gap: 4px;
+  }
+}

--- a/src/components/ReservationCalendar.module.css
+++ b/src/components/ReservationCalendar.module.css
@@ -1,0 +1,35 @@
+.calendarWrap {
+  width: 100%;
+  border: 1px solid rgba(139, 105, 20, 0.26);
+  border-radius: 12px;
+  background: #fff;
+  overflow: hidden;
+  min-height: 760px;
+}
+
+.loading {
+  margin: 0;
+  padding: 14px 18px;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: rgba(74, 64, 53, 0.82);
+  border-bottom: 1px solid rgba(139, 105, 20, 0.18);
+}
+
+.fallback {
+  padding: 24px;
+  border: 1px solid rgba(139, 105, 20, 0.28);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--ryokan-muted);
+}
+
+.fallback p {
+  margin: 0;
+}
+
+.fallbackDetail {
+  margin-top: 8px !important;
+  font-size: 13px;
+  color: var(--ryokan-subtle);
+}

--- a/src/components/ReservationCalendar.tsx
+++ b/src/components/ReservationCalendar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Cal, { getCalApi } from "@calcom/embed-react";
+import { useEffect, useState } from "react";
+import styles from "./ReservationCalendar.module.css";
+
+type ReservationCalendarProps = {
+  calLink: string;
+};
+
+export default function ReservationCalendar({ calLink }: ReservationCalendarProps) {
+  const [uiReady, setUiReady] = useState(false);
+  const [uiError, setUiError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        const cal = await getCalApi();
+        cal("ui", {
+          theme: "light",
+          styles: { branding: { brandColor: "#8B6914" } },
+          hideEventTypeDetails: false,
+        });
+        if (mounted) {
+          setUiReady(true);
+        }
+      } catch (error) {
+        if (mounted) {
+          setUiError(
+            error instanceof Error
+              ? error.message
+              : "予約カレンダーの初期化に失敗しました。",
+          );
+        }
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (uiError) {
+    return (
+      <div className={styles.fallback} role="alert">
+        <p>予約カレンダーを表示できませんでした。</p>
+        <p className={styles.fallbackDetail}>{uiError}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.calendarWrap}>
+      {!uiReady && <p className={styles.loading}>予約カレンダーを読み込んでいます…</p>}
+      <Cal
+        calLink={calLink}
+        style={{ width: "100%", height: "760px", overflow: "scroll" }}
+        config={{ layout: "month_view" }}
+      />
+    </div>
+  );
+}

--- a/src/components/reservation/CalendarSection.tsx
+++ b/src/components/reservation/CalendarSection.tsx
@@ -1,4 +1,16 @@
+import ReservationCalendar from '@/components/ReservationCalendar'
+import { buildCalLinkFromProcessEnv } from '@/lib/calcom'
+
 export function CalendarSection() {
+  let calLink: string | null = null
+  let envError: string | null = null
+
+  try {
+    calLink = buildCalLinkFromProcessEnv()
+  } catch (error) {
+    envError = error instanceof Error ? error.message : '予約設定の読み込みに失敗しました。'
+  }
+
   return (
     <section
       className="flex w-full flex-col items-center"
@@ -8,7 +20,6 @@ export function CalendarSection() {
         gap: 32,
       }}
     >
-      {/* Label */}
       <div className="flex items-center" style={{ gap: 16 }}>
         <span
           className="block"
@@ -31,7 +42,6 @@ export function CalendarSection() {
         </span>
       </div>
 
-      {/* Title */}
       <h2
         style={{
           fontFamily: 'var(--font-heading)',
@@ -44,53 +54,60 @@ export function CalendarSection() {
         ご宿泊日を選択
       </h2>
 
-      {/* Cal.com widget placeholder */}
       <div
-        data-testid="cal-widget"
         className="flex w-full flex-col items-center justify-center"
         style={{
           backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-          height: 400,
+          minHeight: 400,
           borderRadius: 8,
           border: '1px solid rgba(212, 197, 160, 0.2)',
           gap: 16,
+          padding: 12,
         }}
       >
-        <span
-          aria-hidden="true"
-          style={{
-            fontSize: 48,
-            color: 'var(--ryokan-light-gold, #D4C5A0)',
-          }}
-        >
-          📅
-        </span>
-
-        <p
-          className="text-center"
-          style={{
-            fontFamily: 'var(--font-body)',
-            fontSize: 16,
-            fontWeight: 300,
-            color: 'var(--ryokan-subtle, #8B7D6B)',
-            lineHeight: 1.8,
-            whiteSpace: 'pre-line',
-          }}
-        >
-          {'Cal.com カレンダーウィジェット\n埋め込みエリア'}
-        </p>
-
-        <p
-          className="text-center"
-          style={{
-            fontFamily: 'var(--font-body)',
-            fontSize: 12,
-            fontWeight: 300,
-            color: 'var(--ryokan-accent, #C4B89A)',
-          }}
-        >
-          ※ 実際のサイトでは Cal.com のカレンダーが表示されます
-        </p>
+        {calLink ? (
+          <ReservationCalendar calLink={calLink} />
+        ) : (
+          <div
+            role="alert"
+            className="flex w-full flex-col items-center justify-center"
+            style={{ gap: 12, padding: '24px 16px' }}
+          >
+            <h3
+              style={{
+                fontFamily: 'var(--font-heading)',
+                fontSize: 20,
+                fontWeight: 600,
+                color: 'var(--ryokan-dark, #2C2418)',
+              }}
+            >
+              オンライン予約の準備中です
+            </h3>
+            <p
+              className="text-center"
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 14,
+                fontWeight: 300,
+                color: 'var(--ryokan-subtle, #8B7D6B)',
+                lineHeight: 1.8,
+              }}
+            >
+              {envError}
+            </p>
+            <p
+              className="text-center"
+              style={{
+                fontFamily: 'var(--font-body)',
+                fontSize: 13,
+                fontWeight: 300,
+                color: 'var(--ryokan-accent, #C4B89A)',
+              }}
+            >
+              お急ぎの場合はお電話にてお問い合わせください。
+            </p>
+          </div>
+        )}
       </div>
     </section>
   )

--- a/src/lib/calcom.test.ts
+++ b/src/lib/calcom.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildCalLink } from "./calcom";
+
+test("buildCalLink joins username and event slug", () => {
+  const link = buildCalLink({
+    NEXT_PUBLIC_CALCOM_USERNAME: "tsukise-an",
+    NEXT_PUBLIC_CALCOM_EVENT_SLUG: "stay",
+  });
+
+  assert.equal(link, "tsukise-an/stay");
+});
+
+test("buildCalLink trims extra slashes", () => {
+  const link = buildCalLink({
+    NEXT_PUBLIC_CALCOM_USERNAME: "/tsukise-an/",
+    NEXT_PUBLIC_CALCOM_EVENT_SLUG: "/stay/",
+  });
+
+  assert.equal(link, "tsukise-an/stay");
+});
+
+test("buildCalLink throws when username or event slug is empty", () => {
+  assert.throws(
+    () =>
+      buildCalLink({
+        NEXT_PUBLIC_CALCOM_USERNAME: "/",
+        NEXT_PUBLIC_CALCOM_EVENT_SLUG: "stay",
+      }),
+    /must not be empty/,
+  );
+});

--- a/src/lib/calcom.ts
+++ b/src/lib/calcom.ts
@@ -1,0 +1,27 @@
+import { getEnv } from "./env";
+
+export type CalcomLinkEnv = {
+  NEXT_PUBLIC_CALCOM_USERNAME: string;
+  NEXT_PUBLIC_CALCOM_EVENT_SLUG: string;
+};
+
+const normalizeSegment = (value: string): string => value.replace(/^\/+|\/+$/g, "");
+
+export const buildCalLink = (env: CalcomLinkEnv): string => {
+  const username = normalizeSegment(env.NEXT_PUBLIC_CALCOM_USERNAME);
+  const eventSlug = normalizeSegment(env.NEXT_PUBLIC_CALCOM_EVENT_SLUG);
+
+  if (!username || !eventSlug) {
+    throw new Error("Cal.com username/event slug must not be empty.");
+  }
+
+  return `${username}/${eventSlug}`;
+};
+
+export const buildCalLinkFromProcessEnv = (): string => {
+  const env = getEnv();
+  return buildCalLink({
+    NEXT_PUBLIC_CALCOM_USERNAME: env.NEXT_PUBLIC_CALCOM_USERNAME,
+    NEXT_PUBLIC_CALCOM_EVENT_SLUG: env.NEXT_PUBLIC_CALCOM_EVENT_SLUG,
+  });
+};


### PR DESCRIPTION
## Summary
- Implement `/reservation` page with Cal.com embedded calendar.
- Add reusable Cal.com link builder for env-driven routing.
- Add graceful fallback UI when calendar config cannot be loaded.

## Changes
- Add `src/app/reservation/page.tsx` and reservation styles.
- Add `src/components/ReservationCalendar.tsx` + CSS module.
- Add `src/lib/calcom.ts` for cal-link construction.
- Add TDD unit tests in `src/lib/calcom.test.ts`.

## Testing
- [x] `node --test --import tsx src/lib/calcom.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`

## Review Focus
- Env-driven cal link behavior
- Fallback behavior when env/init fails
- Layout impact and static generation for `/reservation`

## Related Issues
- #10
- #12
