### PR TITLE
feat: add contact page with Web3Forms integration

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -8,6 +8,8 @@ import { CTASection } from '@/components/shared/CTASection/CTASection'
 import { Footer } from '@/components/shared/Footer/Footer'
 
 export default function ContactPage() {
+  const accessKey = process.env.NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY ?? ''
+
   return (
     <div className="ryokan-page">
       <Header />
@@ -20,7 +22,7 @@ export default function ContactPage() {
           ]}
         />
         <ContactIntroSection />
-        <ContactFormSection />
+        <ContactFormSection accessKey={accessKey} />
         <ContactInfoSection />
         <CTASection />
       </main>

--- a/src/components/ContactForm.module.css
+++ b/src/components/ContactForm.module.css
@@ -1,0 +1,109 @@
+.form {
+  padding: 30px;
+  border: 1px solid rgba(139, 105, 20, 0.22);
+  border-radius: 14px;
+  background: #fff;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.form label {
+  display: grid;
+  gap: 8px;
+  color: var(--ryokan-muted);
+  font-size: 13px;
+  letter-spacing: 0.03em;
+}
+
+.form label span {
+  color: var(--ryokan-gold);
+}
+
+.form input,
+.form select,
+.form textarea {
+  width: 100%;
+  border: 1px solid rgba(139, 105, 20, 0.25);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: var(--ryokan-dark);
+  background: #fff;
+}
+
+.form textarea {
+  resize: vertical;
+}
+
+.textAreaLabel {
+  margin-top: 8px;
+}
+
+.checkbox {
+  margin-top: 14px;
+  display: inline-flex !important;
+  gap: 10px !important;
+  align-items: center;
+}
+
+.checkbox input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+}
+
+.errorList {
+  margin: 14px 0 0;
+  padding: 0 0 0 18px;
+  color: #9e2a2b;
+  font-size: 13px;
+  display: grid;
+  gap: 4px;
+}
+
+.errorMessage,
+.success {
+  margin: 14px 0 0;
+  font-size: 14px;
+}
+
+.errorMessage {
+  color: #9e2a2b;
+}
+
+.success {
+  color: #1f7a4d;
+}
+
+.submit {
+  margin-top: 18px;
+  border: none;
+  border-radius: 999px;
+  padding: 11px 22px;
+  background: var(--ryokan-gold);
+  color: #fff;
+  font-size: 14px;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.submit:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+@media (max-width: 880px) {
+  .form {
+    padding: 20px;
+  }
+
+  .row {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+
+import {
+  submitContactForm,
+  validateContactInput,
+  type ContactFormInput,
+} from "@/lib/web3forms";
+import styles from "./ContactForm.module.css";
+
+type ContactFormProps = {
+  accessKey?: string;
+};
+
+const SUBJECT_OPTIONS = [
+  "ご予約について",
+  "施設について",
+  "アクセスについて",
+  "その他",
+];
+
+const INITIAL_FORM: ContactFormInput = {
+  name: "",
+  email: "",
+  phone: "",
+  subject: SUBJECT_OPTIONS[0],
+  message: "",
+  agreeToPrivacy: false,
+};
+
+export default function ContactForm({ accessKey = "" }: ContactFormProps) {
+  const [form, setForm] = useState<ContactFormInput>(INITIAL_FORM);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [status, setStatus] = useState<"idle" | "sending" | "success" | "error">(
+    "idle",
+  );
+  const [resultMessage, setResultMessage] = useState("");
+
+  const keyMissing = useMemo(() => accessKey.trim().length === 0, [accessKey]);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const validationErrors = validateContactInput(form);
+    setErrors(validationErrors);
+    if (validationErrors.length > 0 || keyMissing) {
+      setStatus("error");
+      setResultMessage(
+        keyMissing
+          ? "現在フォーム送信設定が未完了です。お電話にてお問い合わせください。"
+          : "入力内容をご確認ください。",
+      );
+      return;
+    }
+
+    setStatus("sending");
+    setResultMessage("");
+    try {
+      const result = await submitContactForm(form, accessKey);
+      if (result.success) {
+        setStatus("success");
+        setResultMessage(result.message);
+        setForm(INITIAL_FORM);
+        setErrors([]);
+        return;
+      }
+      setStatus("error");
+      setResultMessage(result.message);
+    } catch (error) {
+      setStatus("error");
+      setResultMessage(
+        error instanceof Error
+          ? error.message
+          : "送信に失敗しました。お電話にてお問い合わせください。",
+      );
+    }
+  };
+
+  return (
+    <form className={styles.form} onSubmit={onSubmit} noValidate>
+      <div className={styles.row}>
+        <label>
+          お名前<span>*</span>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+            required
+          />
+        </label>
+        <label>
+          メールアドレス<span>*</span>
+          <input
+            type="email"
+            value={form.email}
+            onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+            required
+          />
+        </label>
+      </div>
+
+      <div className={styles.row}>
+        <label>
+          お電話番号
+          <input
+            type="tel"
+            value={form.phone}
+            onChange={(event) => setForm((prev) => ({ ...prev, phone: event.target.value }))}
+          />
+        </label>
+        <label>
+          お問い合わせ種別<span>*</span>
+          <select
+            value={form.subject}
+            onChange={(event) => setForm((prev) => ({ ...prev, subject: event.target.value }))}
+            required
+          >
+            {SUBJECT_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label className={styles.textAreaLabel}>
+        お問い合わせ内容<span>*</span>
+        <textarea
+          value={form.message}
+          onChange={(event) => setForm((prev) => ({ ...prev, message: event.target.value }))}
+          rows={7}
+          required
+        />
+      </label>
+
+      <label className={styles.checkbox}>
+        <input
+          type="checkbox"
+          checked={form.agreeToPrivacy}
+          onChange={(event) =>
+            setForm((prev) => ({ ...prev, agreeToPrivacy: event.target.checked }))
+          }
+        />
+        <span>プライバシーポリシーに同意する</span>
+      </label>
+
+      {errors.length > 0 && (
+        <ul className={styles.errorList}>
+          {errors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      )}
+
+      {resultMessage && (
+        <p className={status === "success" ? styles.success : styles.errorMessage}>
+          {resultMessage}
+        </p>
+      )}
+
+      <button
+        className={styles.submit}
+        type="submit"
+        disabled={status === "sending" || keyMissing}
+      >
+        {status === "sending" ? "送信中..." : "送信する"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/contact/ContactFormSection.tsx
+++ b/src/components/contact/ContactFormSection.tsx
@@ -1,28 +1,12 @@
-import Link from 'next/link'
+import ContactForm from '@/components/ContactForm'
 
-const inputStyle = {
-  fontFamily: 'var(--font-body)',
-  fontSize: 14,
-  fontWeight: 300,
-  color: 'var(--ryokan-dark, #2C2418)',
-  backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-  border: '1px solid var(--ryokan-light-gold, #D4C5A0)',
-  borderRadius: 2,
-  height: 48,
-  padding: '0 16px',
-  width: '100%',
-  outline: 'none',
-} as const
+type ContactFormSectionProps = {
+  accessKey?: string
+}
 
-const labelStyle = {
-  fontFamily: 'var(--font-body)',
-  fontSize: 13,
-  fontWeight: 500,
-  color: 'var(--ryokan-dark, #2C2418)',
-  letterSpacing: 1,
-} as const
+export function ContactFormSection({ accessKey = '' }: ContactFormSectionProps) {
+  const keyMissing = accessKey.trim().length === 0
 
-export function ContactFormSection() {
   return (
     <section
       className="flex w-full flex-col items-center"
@@ -32,18 +16,16 @@ export function ContactFormSection() {
         gap: 40,
       }}
     >
-      {/* Form container */}
-      <form
+      <div
         className="flex w-full flex-col"
         style={{
           backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
           padding: '60px 80px',
-          gap: 32,
+          gap: 24,
           borderRadius: 4,
           border: '1px solid #D4C5A033',
         }}
       >
-        {/* Web3Forms badge */}
         <div
           className="flex items-center"
           style={{
@@ -66,184 +48,23 @@ export function ContactFormSection() {
           </span>
         </div>
 
-        {/* Name row */}
-        <div className="flex w-full gap-6">
-          {/* Last name */}
-          <div className="flex w-full flex-col gap-2">
-            <label htmlFor="contact-last-name" style={labelStyle}>
-              お名前（姓）<span aria-hidden="true">*</span>
-            </label>
-            <input
-              id="contact-last-name"
-              name="lastName"
-              type="text"
-              required
-              placeholder="月瀬"
-              style={inputStyle}
-            />
-          </div>
-
-          {/* First name */}
-          <div className="flex w-full flex-col gap-2">
-            <label htmlFor="contact-first-name" style={labelStyle}>
-              お名前（名）<span aria-hidden="true">*</span>
-            </label>
-            <input
-              id="contact-first-name"
-              name="firstName"
-              type="text"
-              required
-              placeholder="太郎"
-              style={inputStyle}
-            />
-          </div>
-        </div>
-
-        {/* Email and Phone row */}
-        <div className="flex w-full gap-6">
-          {/* Email */}
-          <div className="flex w-full flex-col gap-2">
-            <label htmlFor="contact-email" style={labelStyle}>
-              メールアドレス <span aria-hidden="true">*</span>
-            </label>
-            <input
-              id="contact-email"
-              name="email"
-              type="email"
-              required
-              placeholder="example@email.com"
-              style={inputStyle}
-            />
-          </div>
-
-          {/* Phone */}
-          <div className="flex w-full flex-col gap-2">
-            <label htmlFor="contact-phone" style={labelStyle}>
-              お電話番号
-            </label>
-            <input
-              id="contact-phone"
-              name="phone"
-              type="tel"
-              placeholder="090-1234-5678"
-              style={inputStyle}
-            />
-          </div>
-        </div>
-
-        {/* Subject select */}
-        <div className="flex w-full flex-col gap-2">
-          <label htmlFor="contact-subject" style={labelStyle}>
-            お問い合わせ種別 <span aria-hidden="true">*</span>
-          </label>
-          <select
-            id="contact-subject"
-            name="subject"
-            required
-            defaultValue=""
-            style={{
-              ...inputStyle,
-              appearance: 'none',
-              cursor: 'pointer',
-            }}
-          >
-            <option value="" disabled>
-              お問い合わせ種別を選択
-            </option>
-            <option value="accommodation">ご宿泊について</option>
-            <option value="celebration">お祝い・ご接待について</option>
-            <option value="dining">お食事について</option>
-            <option value="other">その他のお問い合わせ</option>
-          </select>
-        </div>
-
-        {/* Message textarea */}
-        <div className="flex w-full flex-col gap-2">
-          <label htmlFor="contact-message" style={labelStyle}>
-            お問い合わせ内容 <span aria-hidden="true">*</span>
-          </label>
-          <textarea
-            id="contact-message"
-            name="message"
-            required
-            placeholder="ご質問やご要望をご記入ください"
-            style={{
-              fontFamily: 'var(--font-body)',
-              fontSize: 14,
-              fontWeight: 300,
-              color: 'var(--ryokan-dark, #2C2418)',
-              backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-              border: '1px solid var(--ryokan-light-gold, #D4C5A0)',
-              borderRadius: 2,
-              height: 200,
-              padding: 16,
-              width: '100%',
-              outline: 'none',
-              resize: 'vertical',
-            }}
-          />
-        </div>
-
-        {/* Privacy checkbox */}
-        <div className="flex items-center gap-3">
-          <input
-            id="contact-privacy"
-            name="privacy"
-            type="checkbox"
-            required
-            aria-label="プライバシーポリシーに同意する"
-            style={{
-              width: 20,
-              height: 20,
-              accentColor: 'var(--ryokan-gold, #8B6914)',
-              cursor: 'pointer',
-            }}
-          />
-          <label
-            htmlFor="contact-privacy"
+        {keyMissing && (
+          <p
+            role="alert"
             style={{
               fontFamily: 'var(--font-body)',
               fontSize: 13,
               fontWeight: 300,
-              color: 'var(--ryokan-text, #4A4035)',
-              letterSpacing: 1,
-              cursor: 'pointer',
+              color: '#9E2A2B',
+              lineHeight: 1.7,
             }}
           >
-            <Link
-              href="/privacy"
-              style={{
-                color: 'var(--ryokan-text, #4A4035)',
-                textDecoration: 'underline',
-              }}
-            >
-              プライバシーポリシー
-            </Link>
-            に同意する <span aria-hidden="true">*</span>
-          </label>
-        </div>
+            フォーム送信設定が未完了です。`NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY` を設定してください。
+          </p>
+        )}
 
-        {/* Submit button */}
-        <div className="flex w-full justify-center">
-          <button
-            type="submit"
-            style={{
-              backgroundColor: 'var(--ryokan-gold, #8B6914)',
-              padding: '18px 80px',
-              borderRadius: 2,
-              fontFamily: 'var(--font-body)',
-              fontSize: 15,
-              fontWeight: 600,
-              color: 'var(--ryokan-bg, #FAF8F3)',
-              letterSpacing: 4,
-              border: 'none',
-              cursor: 'pointer',
-            }}
-          >
-            送信する
-          </button>
-        </div>
-      </form>
+        <ContactForm accessKey={accessKey} />
+      </div>
     </section>
   )
 }

--- a/src/lib/web3forms.test.ts
+++ b/src/lib/web3forms.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildWeb3FormsPayload,
+  validateContactInput,
+  submitContactForm,
+  type ContactFormInput,
+} from "./web3forms";
+
+const validInput: ContactFormInput = {
+  name: "山田 太郎",
+  email: "guest@example.com",
+  phone: "090-0000-0000",
+  subject: "ご予約について",
+  message: "空室状況を確認したいです。",
+  agreeToPrivacy: true,
+};
+
+test("validateContactInput returns no errors for valid input", () => {
+  const errors = validateContactInput(validInput);
+  assert.equal(errors.length, 0);
+});
+
+test("validateContactInput returns errors for missing required fields", () => {
+  const errors = validateContactInput({
+    ...validInput,
+    name: "",
+    email: "bad-address",
+    message: "",
+    agreeToPrivacy: false,
+  });
+
+  assert.ok(errors.some((err) => err.includes("お名前")));
+  assert.ok(errors.some((err) => err.includes("メールアドレス")));
+  assert.ok(errors.some((err) => err.includes("お問い合わせ内容")));
+  assert.ok(errors.some((err) => err.includes("プライバシーポリシー")));
+});
+
+test("buildWeb3FormsPayload builds expected payload", () => {
+  const payload = buildWeb3FormsPayload(validInput, "test-access-key");
+
+  assert.equal(payload.access_key, "test-access-key");
+  assert.equal(payload.from_name, "月瀬庵ウェブサイト");
+  assert.equal(payload.subject, "【月瀬庵】ご予約について");
+});
+
+test("submitContactForm returns success result from Web3Forms", async () => {
+  const fakeFetch: typeof fetch = (async () =>
+    new Response(JSON.stringify({ success: true, message: "OK" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    })) as typeof fetch;
+
+  const result = await submitContactForm(validInput, "test-access-key", fakeFetch);
+
+  assert.equal(result.success, true);
+  assert.equal(result.message, "OK");
+});

--- a/src/lib/web3forms.ts
+++ b/src/lib/web3forms.ts
@@ -1,0 +1,107 @@
+export type ContactFormInput = {
+  name: string;
+  email: string;
+  phone?: string;
+  subject: string;
+  message: string;
+  agreeToPrivacy: boolean;
+};
+
+export type Web3FormsPayload = {
+  access_key: string;
+  from_name: string;
+  name: string;
+  email: string;
+  phone?: string;
+  subject: string;
+  message: string;
+};
+
+export type Web3FormsResult = {
+  success: boolean;
+  message: string;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const trim = (value: string | undefined): string => (value ?? "").trim();
+
+export const validateContactInput = (input: ContactFormInput): string[] => {
+  const errors: string[] = [];
+
+  if (!trim(input.name)) {
+    errors.push("お名前を入力してください。");
+  }
+
+  const email = trim(input.email);
+  if (!email || !EMAIL_PATTERN.test(email)) {
+    errors.push("メールアドレスを正しく入力してください。");
+  }
+
+  if (!trim(input.subject)) {
+    errors.push("お問い合わせ種別を選択してください。");
+  }
+
+  if (!trim(input.message)) {
+    errors.push("お問い合わせ内容を入力してください。");
+  }
+
+  if (!input.agreeToPrivacy) {
+    errors.push("プライバシーポリシーへの同意が必要です。");
+  }
+
+  return errors;
+};
+
+export const buildWeb3FormsPayload = (
+  input: ContactFormInput,
+  accessKey: string,
+): Web3FormsPayload => {
+  const key = trim(accessKey);
+  if (!key) {
+    throw new Error("Web3Forms access key is missing.");
+  }
+
+  return {
+    access_key: key,
+    from_name: "月瀬庵ウェブサイト",
+    name: trim(input.name),
+    email: trim(input.email),
+    phone: trim(input.phone) || undefined,
+    subject: `【月瀬庵】${trim(input.subject)}`,
+    message: trim(input.message),
+  };
+};
+
+export const submitContactForm = async (
+  input: ContactFormInput,
+  accessKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Web3FormsResult> => {
+  const errors = validateContactInput(input);
+  if (errors.length > 0) {
+    throw new Error(errors.join("\n"));
+  }
+
+  const payload = buildWeb3FormsPayload(input, accessKey);
+  const response = await fetchImpl("https://api.web3forms.com/submit", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const data = (await response.json()) as Partial<Web3FormsResult>;
+  if (!response.ok || !data.success) {
+    return {
+      success: false,
+      message:
+        data.message ??
+        "送信に失敗しました。お手数ですがお電話にてお問い合わせください。",
+    };
+  }
+
+  return {
+    success: true,
+    message: data.message ?? "送信が完了しました。",
+  };
+};


### PR DESCRIPTION
## Summary
- Implement `/contact` page and client contact form.
- Add Web3Forms integration with validation and submission states.
- Add unit tests for validation/payload/submission behavior.

## Changes
- Add `src/app/contact/page.tsx` and contact page styles.
- Add `src/components/ContactForm.tsx` + CSS module.
- Add `src/lib/web3forms.ts` for form validation and submit logic.
- Add `src/lib/web3forms.test.ts`.

## Testing
- [x] `node --test --import tsx src/lib/web3forms.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build`

## Review Focus
- Required-field validation and privacy consent handling
- Web3Forms payload format and error fallback behavior
- UI state transitions (sending/success/error)

## Related Issues
- #10
- #13
