### PR TITLE
fix: checkout PR head for @claude issue_comment

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -33,7 +33,15 @@ jobs:
           echo "CLAUDE_CODE_OAUTH_TOKEN is not set."
           exit 1
 
-      - name: Checkout
+      - name: Checkout PR head (issue_comment on PR)
+        if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request }}
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
+
+      - name: Checkout default ref
+        if: ${{ !(github.event_name == 'issue_comment' && github.event.issue.pull_request) }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 1


### PR DESCRIPTION
## Summary
- Fix `@claude` runs on PR comments by checking out the PR head branch.

## Changes
- For `issue_comment` events on PRs, checkout `refs/pull/<issue.number>/head`.
- Keep default checkout path for non-PR comments.

## Why
- Previous workflow checked out `main`, so changed files in PR were missing and Claude action failed while hashing files.

## Related Issues
- #26
