### PR TITLE
fix: pin claude review action to v1.0.51

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Code Action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@ea36d6abdedc17fc2a671b36060770b208a6f8f1 # v1.0.51 (pinned to avoid current SDK AJV crash)
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |


### PR DESCRIPTION
## Summary
- pin `anthropics/claude-code-action` from moving `@v1` to commit for `v1.0.51`
- workaround current upstream AJV/SDK crash observed in `@claude` runs

## Verification
- trigger `@claude` comment on PR after merge and confirm `Claude Review` succeeds
