### PR TITLE
fix: limit claude setting sources to project/local

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -52,3 +52,4 @@ jobs:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --max-turns 10
+            --setting-sources project,local


### PR DESCRIPTION
## Summary
- keep `claude-code-action` pinned at `v1.0.51`
- add `--setting-sources project,local` to avoid loading user-level settings during action execution

## Why
- `@claude` still failed with AJV `dependencies` schema crash even after pinning
- upstream SDK logs show settingSources included `user,project,local`; this workaround removes `user` source from runtime

## Verification
- after merge, trigger `@claude` on PR #66 and confirm `Claude Review` passes
