### PR TITLE
feat(#72): Hero/CTA背景画像実装

### DIFF
--- a/src/components/shared/CTASection/CTASection.tsx
+++ b/src/components/shared/CTASection/CTASection.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import Link from 'next/link'
 
 export function CTASection() {
@@ -7,10 +8,13 @@ export function CTASection() {
       style={{ height: 480 }}
     >
       {/* Background image */}
-      <div
-        data-testid="cta-bg"
-        className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundColor: 'var(--ryokan-darkest, #1A150E)' }}
+      <Image
+        src="/images/cta.png"
+        alt="月瀬庵の夜景"
+        fill
+        className="object-cover"
+        quality={85}
+        sizes="100vw"
       />
 
       {/* Overlay */}

--- a/src/components/shared/CTASection/__tests__/CTASection.test.tsx
+++ b/src/components/shared/CTASection/__tests__/CTASection.test.tsx
@@ -34,4 +34,12 @@ describe('CTASection', () => {
       screen.getByText('ご予約・お問い合わせはお電話またはオンラインにて承ります')
     ).toBeInTheDocument()
   })
+
+  it('renders a background image with src containing cta.png', () => {
+    render(<CTASection />)
+    const img = screen.getByAltText('月瀬庵の夜景')
+    expect(img).toBeInTheDocument()
+    expect(img.tagName).toBe('IMG')
+    expect(img).toHaveAttribute('src', expect.stringContaining('cta.png'))
+  })
 })

--- a/src/components/top/HeroSection.tsx
+++ b/src/components/top/HeroSection.tsx
@@ -1,14 +1,20 @@
+import Image from 'next/image'
+
 export function HeroSection() {
   return (
     <section
       className="relative w-full overflow-hidden"
       style={{ height: 780 }}
     >
-      {/* Background image placeholder */}
-      <div
-        className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundColor: 'var(--ryokan-darkest)' }}
-        aria-hidden="true"
+      {/* Background image */}
+      <Image
+        src="/images/hero.png"
+        alt="芦ノ湖畔の月瀬庵"
+        fill
+        className="object-cover"
+        priority
+        quality={85}
+        sizes="100vw"
       />
 
       {/* Overlay */}

--- a/src/components/top/__tests__/HeroSection.test.tsx
+++ b/src/components/top/__tests__/HeroSection.test.tsx
@@ -26,4 +26,17 @@ describe('HeroSection', () => {
     render(<HeroSection />)
     expect(screen.getByText('箱根 芦ノ湖畔')).toBeInTheDocument()
   })
+
+  it('renders a background image with alt text "芦ノ湖畔の月瀬庵"', () => {
+    render(<HeroSection />)
+    const img = screen.getByAltText('芦ノ湖畔の月瀬庵')
+    expect(img).toBeInTheDocument()
+    expect(img.tagName).toBe('IMG')
+  })
+
+  it('renders the background image with src containing hero.png', () => {
+    render(<HeroSection />)
+    const img = screen.getByAltText('芦ノ湖畔の月瀬庵')
+    expect(img).toHaveAttribute('src', expect.stringContaining('hero.png'))
+  })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: [path.resolve(__dirname, './src/test/setup.ts')],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['src/lib/env.test.ts', 'node_modules'],
     css: true,


### PR DESCRIPTION
## Summary
- HeroSection に `/images/hero.png` を next/image で実装
- CTASection に `/images/cta.png` を next/image で実装
- priority / sizes / quality の最適化設定
- TDD: テスト追加済み

## Test plan
- [ ] `npx vitest run` が pass する
- [ ] Hero セクションに背景画像が表示される
- [ ] CTA セクションに背景画像が表示される

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)