### PR TITLE
feat(#73): Rooms/Onsenセクション画像実装

### DIFF
--- a/src/components/top/OnsenSection.tsx
+++ b/src/components/top/OnsenSection.tsx
@@ -1,9 +1,10 @@
+import Image from 'next/image'
 import Link from 'next/link'
 
 export function OnsenSection() {
   return (
     <section className="flex w-full" style={{ height: 560 }}>
-      {/* Content area (left side) */}
+      {/* Left: Content area (light bg) */}
       <div
         className="flex flex-1 flex-col justify-center"
         style={{
@@ -94,16 +95,23 @@ export function OnsenSection() {
         </Link>
       </div>
 
-      {/* Image area (right side) */}
+      {/* Right: Onsen image (800px wide) */}
       <div
         className="relative overflow-hidden"
         style={{
           width: 800,
           height: 560,
-          backgroundColor: 'var(--ryokan-dark)',
           flexShrink: 0,
         }}
-      />
+      >
+        <Image
+          src="/images/onsen.png"
+          alt="月瀬庵の露天風呂"
+          fill
+          className="object-cover"
+          sizes="800px"
+        />
+      </div>
     </section>
   )
 }

--- a/src/components/top/RoomSection.tsx
+++ b/src/components/top/RoomSection.tsx
@@ -1,20 +1,28 @@
+import Image from 'next/image'
 import Link from 'next/link'
 
 export function RoomSection() {
   return (
     <section className="flex w-full" style={{ height: 560 }}>
-      {/* Image area */}
+      {/* Left: Room image (800px wide) */}
       <div
         className="relative overflow-hidden"
         style={{
           width: 800,
           height: 560,
-          backgroundColor: 'var(--ryokan-dark)',
           flexShrink: 0,
         }}
-      />
+      >
+        <Image
+          src="/images/room.png"
+          alt="月瀬庵の客室"
+          fill
+          className="object-cover"
+          sizes="800px"
+        />
+      </div>
 
-      {/* Content area */}
+      {/* Right: Content area (dark bg) */}
       <div
         className="flex flex-1 flex-col justify-center"
         style={{

--- a/src/components/top/__tests__/OnsenSection.test.tsx
+++ b/src/components/top/__tests__/OnsenSection.test.tsx
@@ -7,9 +7,11 @@ describe('OnsenSection', () => {
     expect(screen.getByText('ONSEN')).toBeInTheDocument()
   })
 
-  it('renders the section title about onsen', () => {
+  it('renders the section title with 湖を望む and 湯処', () => {
     render(<OnsenSection />)
-    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/湖を望む/)
+    const heading = screen.getByRole('heading', { level: 2 })
+    expect(heading).toHaveTextContent(/湖を望む/)
+    expect(heading).toHaveTextContent(/湯処/)
   })
 
   it('renders the description about the hot spring source', () => {
@@ -26,5 +28,27 @@ describe('OnsenSection', () => {
   it('renders with content area on the left and image on the right', () => {
     const { container } = render(<OnsenSection />)
     expect(container.querySelector('section')).toBeInTheDocument()
+  })
+
+  it('renders an onsen image with appropriate alt text', () => {
+    render(<OnsenSection />)
+    const img = screen.getByRole('img', { name: /露天風呂/ })
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders the onsen image with correct src', () => {
+    render(<OnsenSection />)
+    const img = screen.getByRole('img', { name: /露天風呂/ })
+    expect(img).toHaveAttribute('src', expect.stringContaining('onsen.png'))
+  })
+
+  it('renders content on the left and image on the right', () => {
+    const { container } = render(<OnsenSection />)
+    const section = container.querySelector('section')!
+    const children = Array.from(section.children) as HTMLElement[]
+    // First child should contain the text content, second child should contain the image
+    expect(children.length).toBe(2)
+    expect(children[0]).toHaveTextContent(/湖を望む/)
+    expect(children[1].querySelector('img')).toBeInTheDocument()
   })
 })

--- a/src/components/top/__tests__/RoomSection.test.tsx
+++ b/src/components/top/__tests__/RoomSection.test.tsx
@@ -7,9 +7,11 @@ describe('RoomSection', () => {
     expect(screen.getByText('ROOMS')).toBeInTheDocument()
   })
 
-  it('renders the section title about rooms', () => {
+  it('renders the section title with 全八室の and 離れ', () => {
     render(<RoomSection />)
-    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(/全八室/)
+    const heading = screen.getByRole('heading', { level: 2 })
+    expect(heading).toHaveTextContent(/全八室の/)
+    expect(heading).toHaveTextContent(/離れ/)
   })
 
   it('renders the description about private cottages', () => {
@@ -26,5 +28,27 @@ describe('RoomSection', () => {
   it('renders as a section element with dark background content area', () => {
     const { container } = render(<RoomSection />)
     expect(container.querySelector('section')).toBeInTheDocument()
+  })
+
+  it('renders a room image with appropriate alt text', () => {
+    render(<RoomSection />)
+    const img = screen.getByRole('img', { name: /客室/ })
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders the room image with correct src', () => {
+    render(<RoomSection />)
+    const img = screen.getByRole('img', { name: /客室/ })
+    expect(img).toHaveAttribute('src', expect.stringContaining('room.png'))
+  })
+
+  it('renders image on the left and content on the right', () => {
+    const { container } = render(<RoomSection />)
+    const section = container.querySelector('section')!
+    const children = Array.from(section.children) as HTMLElement[]
+    // First child should contain the image, second child should contain the text content
+    expect(children.length).toBe(2)
+    expect(children[0].querySelector('img')).toBeInTheDocument()
+    expect(children[1]).toHaveTextContent(/全八室/)
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: [path.resolve(__dirname, './src/test/setup.ts')],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['src/lib/env.test.ts', 'node_modules'],
     css: true,


### PR DESCRIPTION
## Summary
- RoomSection に `/images/room.png` を追加（左画像 + 右テキスト dark bg）
- OnsenSection に `/images/onsen.png` を追加（左テキスト light bg + 右画像）
- .pen デザインのレイアウトに合わせた配置
- TDD: テスト追加済み

## Test plan
- [ ] `npx vitest run` が pass する
- [ ] Room セクション: 左に客室画像、右にダーク背景のテキスト
- [ ] Onsen セクション: 左にライト背景テキスト、右に温泉画像

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)