### PR TITLE
feat(#74): Cuisine/Stayセクション画像実装

### DIFF
--- a/src/components/top/CuisineSection.tsx
+++ b/src/components/top/CuisineSection.tsx
@@ -1,15 +1,19 @@
+import Image from 'next/image'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 
 const dishes = [
   {
+    image: '/images/cuisine-hassun.png',
     title: '八寸',
     description: '旬の食材を彩り豊かに',
   },
   {
+    image: '/images/cuisine-yakimono.png',
     title: '焼物',
     description: '相模湾直送の炭火焼き',
   },
   {
+    image: '/images/cuisine-mizugashi.png',
     title: '水菓子',
     description: '季節を映す和の甘味',
   },
@@ -68,14 +72,22 @@ export function CuisineSection() {
       <div className="flex w-full gap-6">
         {dishes.map((dish) => (
           <div key={dish.title} className="flex flex-1 flex-col items-center gap-4">
-            {/* Image placeholder */}
+            {/* Card image */}
             <div
-              className="w-full overflow-hidden"
+              className="relative w-full overflow-hidden"
               style={{
                 aspectRatio: '4/3',
                 backgroundColor: 'var(--ryokan-darkest)',
               }}
-            />
+            >
+              <Image
+                src={dish.image}
+                alt={dish.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 33vw"
+              />
+            </div>
             <h3
               style={{
                 fontFamily: 'var(--font-heading)',

--- a/src/components/top/StaySection.tsx
+++ b/src/components/top/StaySection.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image'
 import { SectionLabel } from '@/components/shared/SectionLabel'
 
 const timelineEvening = [
@@ -5,21 +6,25 @@ const timelineEvening = [
     hour: '15:00',
     title: 'お出迎え',
     description: '抹茶と季節の和菓子で\nお迎えいたします',
+    image: '/images/stay-1500.png',
   },
   {
     hour: '17:00',
     title: '庭園散策',
     description: '回遊式庭園と苔庭を\nゆったりと巡ります',
+    image: '/images/stay-1700.jpg',
   },
   {
     hour: '18:30',
     title: '夕食・懐石',
     description: '個室にて月替わりの\n懐石料理をお楽しみに',
+    image: '/images/stay-1830.png',
   },
   {
     hour: '21:00',
     title: '月見の湯',
     description: '月明かりに照らされた\n露天風呂で至福のひとときを',
+    image: '/images/stay-2100.png',
   },
 ]
 
@@ -28,15 +33,27 @@ const timelineMorning = [
     hour: '08:00',
     title: '朝食',
     description: '箱根の朝を感じる\n和の朝ごはん',
+    image: '/images/stay-0800.png',
   },
   {
     hour: '11:00',
     title: 'お見送り',
     description: '芦ノ湖の景色を胸に\nお帰りの途へ',
+    image: '/images/stay-1100.png',
   },
 ]
 
-function TimelineCard({ hour, title, description }: { hour: string; title: string; description: string }) {
+function TimelineCard({
+  hour,
+  title,
+  description,
+  image,
+}: {
+  hour: string
+  title: string
+  description: string
+  image: string
+}) {
   return (
     <div className="flex flex-1 flex-col items-center gap-3">
       {/* Hour */}
@@ -52,14 +69,22 @@ function TimelineCard({ hour, title, description }: { hour: string; title: strin
         {hour}
       </span>
 
-      {/* Image placeholder */}
+      {/* Timeline image */}
       <div
-        className="w-full overflow-hidden"
+        className="relative w-full overflow-hidden"
         style={{
           aspectRatio: '4/3',
           backgroundColor: 'var(--ryokan-light-bg)',
         }}
-      />
+      >
+        <Image
+          src={image}
+          alt={title}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, 25vw"
+        />
+      </div>
 
       {/* Title */}
       <h3

--- a/src/components/top/__tests__/CuisineSection.test.tsx
+++ b/src/components/top/__tests__/CuisineSection.test.tsx
@@ -29,4 +29,38 @@ describe('CuisineSection', () => {
     const section = container.querySelector('section')
     expect(section).toBeInTheDocument()
   })
+
+  it('renders 3 cuisine card images', () => {
+    render(<CuisineSection />)
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(3)
+  })
+
+  it('renders hassun image with correct alt text', () => {
+    render(<CuisineSection />)
+    const img = screen.getByAltText('八寸')
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders yakimono image with correct alt text', () => {
+    render(<CuisineSection />)
+    const img = screen.getByAltText('焼物')
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders mizugashi image with correct alt text', () => {
+    render(<CuisineSection />)
+    const img = screen.getByAltText('水菓子')
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders cuisine images with correct src paths', () => {
+    const { container } = render(<CuisineSection />)
+    const imgElements = container.querySelectorAll('img')
+    const srcValues = Array.from(imgElements).map((img) => img.getAttribute('src') ?? '')
+
+    expect(srcValues.some((src) => src.includes('cuisine-hassun'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('cuisine-yakimono'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('cuisine-mizugashi'))).toBe(true)
+  })
 })

--- a/src/components/top/__tests__/StaySection.test.tsx
+++ b/src/components/top/__tests__/StaySection.test.tsx
@@ -33,4 +33,37 @@ describe('StaySection', () => {
     render(<StaySection />)
     expect(screen.getByText('翌 朝')).toBeInTheDocument()
   })
+
+  it('renders 6 timeline images', () => {
+    render(<StaySection />)
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(6)
+  })
+
+  it('renders timeline images with correct alt text for evening items', () => {
+    render(<StaySection />)
+    expect(screen.getByAltText('お出迎え')).toBeInTheDocument()
+    expect(screen.getByAltText('庭園散策')).toBeInTheDocument()
+    expect(screen.getByAltText('夕食・懐石')).toBeInTheDocument()
+    expect(screen.getByAltText('月見の湯')).toBeInTheDocument()
+  })
+
+  it('renders timeline images with correct alt text for morning items', () => {
+    render(<StaySection />)
+    expect(screen.getByAltText('朝食')).toBeInTheDocument()
+    expect(screen.getByAltText('お見送り')).toBeInTheDocument()
+  })
+
+  it('renders timeline images with correct src paths', () => {
+    const { container } = render(<StaySection />)
+    const imgElements = container.querySelectorAll('img')
+    const srcValues = Array.from(imgElements).map((img) => img.getAttribute('src') ?? '')
+
+    expect(srcValues.some((src) => src.includes('stay-1500'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('stay-1700'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('stay-1830'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('stay-2100'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('stay-0800'))).toBe(true)
+    expect(srcValues.some((src) => src.includes('stay-1100'))).toBe(true)
+  })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: [path.resolve(__dirname, './src/test/setup.ts')],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['src/lib/env.test.ts', 'node_modules'],
     css: true,


### PR DESCRIPTION
## Summary
- CuisineSection に3枚の料理画像追加（八寸/焼物/水菓子）with `next/image` fill prop
- StaySection に6枚のタイムライン画像追加 with `next/image` fill prop
- 画像プレースホルダーを実際の Image コンポーネントに置換
- レスポンシブ `sizes` 属性で最適な画像ロード
- vitest setupFiles パスを `path.resolve` に修正（worktree互換性）

## Test plan
- [x] `npx vitest run` が全416テスト pass する（regression なし）
- [ ] Cuisine: 3枚の料理カード画像が表示される
- [ ] Stay: 6枚のタイムライン画像が表示される
- [ ] 画像に適切な alt テキストが設定されている

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)