### PR TITLE
fix(#79): トップページ デザイン微調整

### DIFF
--- a/docs/design-data/design-tokens.json
+++ b/docs/design-data/design-tokens.json
@@ -3,7 +3,7 @@
     "background": {
       "primary": "#FAF8F3",
       "sectionAlt": "#EEEBE3",
-      "sectionAltDark": "#F0EBE0",
+      "sectionAltDark": "#F5F0E8",
       "dark": "#2C2418",
       "darkest": "#1A150E",
       "hero-overlay": "#1A150E55"
@@ -134,7 +134,7 @@
     "--ryokan-subtle": "#8B7D6B",
     "--ryokan-secondary": "#6B5D4F",
     "--ryokan-light-bg": "#EEEBE3",
-    "--ryokan-light-bg-alt": "#F0EBE0",
+    "--ryokan-light-bg-alt": "#F5F0E8",
     "--ryokan-darkest": "#1A150E",
     "--ryokan-soft-line": "#D4C5A055",
     "--ryokan-text-on-dark": "#FAF8F3",

--- a/src/components/top/ConceptSection.tsx
+++ b/src/components/top/ConceptSection.tsx
@@ -6,7 +6,7 @@ export function ConceptSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg)',
-        padding: '120px 160px',
+        padding: '120px 80px',
         gap: 56,
       }}
     >
@@ -17,10 +17,10 @@ export function ConceptSection() {
       <h2
         style={{
           fontFamily: 'var(--font-heading)',
-          fontSize: 36,
+          fontSize: 32,
           fontWeight: 600,
           color: 'var(--ryokan-dark)',
-          letterSpacing: 6,
+          letterSpacing: 4,
           textAlign: 'center',
           margin: 0,
         }}
@@ -32,13 +32,13 @@ export function ConceptSection() {
       <p
         style={{
           fontFamily: 'var(--font-body)',
-          fontSize: 16,
+          fontSize: 15,
           fontWeight: 300,
           color: 'var(--ryokan-muted)',
-          letterSpacing: 1.5,
+          letterSpacing: 1,
           lineHeight: 2,
           textAlign: 'center',
-          maxWidth: 720,
+          maxWidth: 640,
           margin: 0,
         }}
       >

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -7,7 +7,7 @@
   /* Colors - Background */
   --ryokan-bg: #FAF8F3;
   --ryokan-light-bg: #EEEBE3;
-  --ryokan-light-bg-alt: #F0EBE0;
+  --ryokan-light-bg-alt: #F5F0E8;
   --ryokan-dark: #2C2418;
   --ryokan-darkest: #1A150E;
   --ryokan-hero-overlay: #1A150E55;


### PR DESCRIPTION
## Summary
- Fix ConceptSection typography: fontSize 36->32, letterSpacing 6->4 to match .pen design
- Fix ConceptSection spacing: horizontal padding 160px->80px, description maxWidth 720->640, letterSpacing 1.5->1, fontSize 16->15
- Fix InfoSection background color token: --ryokan-light-bg-alt from #F0EBE0 to #F5F0E8 to match .pen design
- Update design-tokens.json source of truth to reflect correct .pen values

## Test plan
- [x] All 425 tests pass (57 test files)
- [x] Design token test validates CSS matches JSON source of truth
- [ ] Visual check: ConceptSection title is 32px with 4px letter-spacing
- [ ] Visual check: ConceptSection body text is 15px with max-width 640px
- [ ] Visual check: InfoSection background color matches #F5F0E8

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)