### PR TITLE
feat(#14): implement microCMS client for news and faq

### DIFF
--- a/src/lib/microcms.test.ts
+++ b/src/lib/microcms.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MicroCMSListResponse, MicroCMSQueries } from "microcms-js-sdk";
+
+import {
+  getFaqList,
+  getNewsDetail,
+  getNewsList,
+  getRelatedNews,
+  type FaqContent,
+  type MicroCMSReadClient,
+  type NewsContent,
+} from "./microcms";
+
+type GetListRequest = {
+  endpoint: string;
+  queries?: MicroCMSQueries;
+};
+
+type CallRecorder = {
+  calls: GetListRequest[];
+  client: MicroCMSReadClient;
+};
+
+const createRecorder = <T>(response: MicroCMSListResponse<T>): CallRecorder => {
+  const calls: GetListRequest[] = [];
+  const client: MicroCMSReadClient = {
+    getList: async <U = unknown>(request: GetListRequest) => {
+      calls.push(request);
+      return response as unknown as MicroCMSListResponse<U>;
+    },
+  };
+  return { calls, client };
+};
+
+test("getNewsList builds category/pagination queries", async () => {
+  const recorder = createRecorder<NewsContent>({
+    contents: [],
+    totalCount: 0,
+    limit: 6,
+    offset: 6,
+  });
+
+  await getNewsList(
+    { page: 2, limit: 6, category: "イベント" },
+    recorder.client,
+  );
+
+  assert.deepEqual(recorder.calls[0], {
+    endpoint: "news",
+    queries: {
+      limit: 6,
+      offset: 6,
+      orders: "-publishedAt",
+      filters: "category[equals]イベント",
+    },
+  });
+});
+
+test("getNewsDetail fetches by slug and returns first content", async () => {
+  const news = {
+    id: "n1",
+    createdAt: "2026-02-22T00:00:00.000Z",
+    updatedAt: "2026-02-22T00:00:00.000Z",
+    title: "記事",
+    slug: "sample",
+    category: "お知らせ",
+    body: "body",
+    description: "desc",
+  };
+  const recorder = createRecorder<NewsContent>({
+    contents: [news],
+    totalCount: 1,
+    limit: 1,
+    offset: 0,
+  });
+
+  const result = await getNewsDetail("sample", recorder.client);
+
+  assert.equal(result?.id, "n1");
+  assert.deepEqual(recorder.calls[0], {
+    endpoint: "news",
+    queries: {
+      limit: 1,
+      offset: 0,
+      orders: "-publishedAt",
+      filters: "slug[equals]sample",
+    },
+  });
+});
+
+test("getNewsDetail returns null when no content matches", async () => {
+  const recorder = createRecorder<NewsContent>({
+    contents: [],
+    totalCount: 0,
+    limit: 1,
+    offset: 0,
+  });
+
+  const result = await getNewsDetail("missing", recorder.client);
+
+  assert.equal(result, null);
+});
+
+test("getRelatedNews excludes current article id", async () => {
+  const recorder = createRecorder<NewsContent>({
+    contents: [],
+    totalCount: 0,
+    limit: 3,
+    offset: 0,
+  });
+
+  await getRelatedNews("イベント", "news-1", 3, recorder.client);
+
+  assert.deepEqual(recorder.calls[0], {
+    endpoint: "news",
+    queries: {
+      limit: 3,
+      offset: 0,
+      orders: "-publishedAt",
+      filters: "category[equals]イベント[and]id[not_equals]news-1",
+    },
+  });
+});
+
+test("getFaqList fetches ordered FAQ items", async () => {
+  const recorder = createRecorder<FaqContent>({
+    contents: [],
+    totalCount: 0,
+    limit: 100,
+    offset: 0,
+  });
+
+  await getFaqList(recorder.client);
+
+  assert.deepEqual(recorder.calls[0], {
+    endpoint: "faq",
+    queries: {
+      limit: 100,
+      orders: "order",
+    },
+  });
+});

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -1,0 +1,166 @@
+import {
+  createClient,
+  type MicroCMSDate,
+  type MicroCMSImage,
+  type MicroCMSListResponse,
+} from "microcms-js-sdk";
+
+import { getEnv } from "./env";
+
+const NEWS_ENDPOINT = "news";
+const FAQ_ENDPOINT = "faq";
+
+const DEFAULT_NEWS_LIMIT = 10;
+const DEFAULT_RELATED_NEWS_LIMIT = 3;
+const DEFAULT_FAQ_LIMIT = 100;
+
+export type MicroCMSReadClient = Pick<
+  ReturnType<typeof createClient>,
+  "getList"
+>;
+
+type MicroCMSListMeta = {
+  id: string;
+} & MicroCMSDate;
+
+export type NewsContent = {
+  title: string;
+  slug: string;
+  category: string;
+  eyecatch?: MicroCMSImage;
+  description?: string;
+  body: string;
+};
+
+export type NewsItem = NewsContent & MicroCMSListMeta;
+
+export type FaqContent = {
+  question: string;
+  answer: string;
+  category: string;
+  order: number;
+};
+
+export type FaqItem = FaqContent & MicroCMSListMeta;
+
+export type NewsListParams = {
+  page?: number;
+  category?: string;
+  limit?: number;
+};
+
+const toPositiveInt = (value: number | undefined, fallback: number): number => {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.floor(value as number));
+};
+
+const normalizeFilterValue = (value: string): string => value.trim();
+
+const buildNewsCategoryFilter = (category: string | undefined): string | undefined => {
+  if (!category) return undefined;
+  const normalized = normalizeFilterValue(category);
+  return normalized.length > 0 ? `category[equals]${normalized}` : undefined;
+};
+
+const buildNewsSlugFilter = (slug: string): string => {
+  const normalized = normalizeFilterValue(slug);
+  if (!normalized) {
+    throw new Error("slug must not be empty.");
+  }
+  return `slug[equals]${normalized}`;
+};
+
+const buildRelatedNewsFilter = (category: string, excludeId: string): string => {
+  const normalizedCategory = normalizeFilterValue(category);
+  const normalizedExcludeId = normalizeFilterValue(excludeId);
+
+  if (!normalizedCategory) {
+    throw new Error("category must not be empty.");
+  }
+  if (!normalizedExcludeId) {
+    throw new Error("excludeId must not be empty.");
+  }
+
+  return `category[equals]${normalizedCategory}[and]id[not_equals]${normalizedExcludeId}`;
+};
+
+let cachedClient: MicroCMSReadClient | undefined;
+
+export const getMicroCMSClient = (): MicroCMSReadClient => {
+  if (!cachedClient) {
+    const env = getEnv();
+    cachedClient = createClient({
+      serviceDomain: env.MICROCMS_SERVICE_DOMAIN,
+      apiKey: env.MICROCMS_API_KEY,
+    });
+  }
+  return cachedClient;
+};
+
+export const getNewsList = async (
+  params: NewsListParams = {},
+  client: MicroCMSReadClient = getMicroCMSClient(),
+): Promise<MicroCMSListResponse<NewsContent>> => {
+  const limit = toPositiveInt(params.limit, DEFAULT_NEWS_LIMIT);
+  const page = toPositiveInt(params.page, 1);
+  const offset = (page - 1) * limit;
+  const filters = buildNewsCategoryFilter(params.category);
+
+  return client.getList<NewsContent>({
+    endpoint: NEWS_ENDPOINT,
+    queries: {
+      limit,
+      offset,
+      orders: "-publishedAt",
+      ...(filters ? { filters } : {}),
+    },
+  });
+};
+
+export const getNewsDetail = async (
+  slug: string,
+  client: MicroCMSReadClient = getMicroCMSClient(),
+): Promise<NewsItem | null> => {
+  const response = await client.getList<NewsContent>({
+    endpoint: NEWS_ENDPOINT,
+    queries: {
+      limit: 1,
+      offset: 0,
+      orders: "-publishedAt",
+      filters: buildNewsSlugFilter(slug),
+    },
+  });
+
+  return response.contents[0] ?? null;
+};
+
+export const getRelatedNews = async (
+  category: string,
+  excludeId: string,
+  limit = DEFAULT_RELATED_NEWS_LIMIT,
+  client: MicroCMSReadClient = getMicroCMSClient(),
+): Promise<MicroCMSListResponse<NewsContent>> => {
+  const safeLimit = toPositiveInt(limit, DEFAULT_RELATED_NEWS_LIMIT);
+
+  return client.getList<NewsContent>({
+    endpoint: NEWS_ENDPOINT,
+    queries: {
+      limit: safeLimit,
+      offset: 0,
+      orders: "-publishedAt",
+      filters: buildRelatedNewsFilter(category, excludeId),
+    },
+  });
+};
+
+export const getFaqList = async (
+  client: MicroCMSReadClient = getMicroCMSClient(),
+): Promise<MicroCMSListResponse<FaqContent>> => {
+  return client.getList<FaqContent>({
+    endpoint: FAQ_ENDPOINT,
+    queries: {
+      limit: DEFAULT_FAQ_LIMIT,
+      orders: "order",
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add `src/lib/microcms.ts` as a typed microCMS read client layer
- implement backend helper functions required by BE-04:
  - `getNewsList({ page, category, limit })`
  - `getNewsDetail(slug)`
  - `getRelatedNews(category, excludeId, limit?)`
  - `getFaqList()`
- add `src/lib/microcms.test.ts` with TDD coverage for query construction and return behavior

## Notes
- client creation is lazy and env-driven via `getEnv()`
- functions accept an optional injected client to keep tests deterministic and offline

## Validation
- `node --test --import tsx src/lib/microcms.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Refs #14
