### PR TITLE
feat(#17): implement /faq category view with microCMS data

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -6,40 +6,21 @@ import { FAQCategorySection } from '@/components/faq/FAQCategorySection'
 import { FAQContactSection } from '@/components/faq/FAQContactSection'
 import { CTASection } from '@/components/shared/CTASection/CTASection'
 import { Footer } from '@/components/shared/Footer/Footer'
+import { groupFaqByCategory } from '@/lib/faq'
+import { getFaqList } from '@/lib/microcms'
 
-const reservationFAQ = [
-  {
-    question: '予約はいつから可能ですか？',
-    answer:
-      'ご宿泊日の6ヶ月前より、オンラインまたはお電話にてご予約を承っております。特に桜や紅葉の季節は大変人気がございますので、お早めのご予約をお勧めいたします。',
-  },
-  {
-    question: 'キャンセル料はかかりますか？',
-  },
-  {
-    question: 'チェックイン・チェックアウトの時間は？',
-  },
-]
+export default async function FAQPage() {
+  let sections: ReturnType<typeof groupFaqByCategory> = []
+  let fetchError = ''
 
-const onsenRoomFAQ = [
-  { question: '客室の露天風呂は24時間利用できますか？' },
-  { question: '大浴場の営業時間を教えてください。' },
-  { question: 'お部屋にアメニティはありますか？' },
-]
+  try {
+    const response = await getFaqList()
+    sections = groupFaqByCategory(response.contents)
+  } catch (error) {
+    fetchError = '現在FAQを取得できません。時間をおいて再度お試しください。'
+    console.error('Failed to fetch faq list', error)
+  }
 
-const cuisineFAQ = [
-  { question: 'アレルギー対応はしていただけますか？' },
-  { question: 'お食事の時間は選べますか？' },
-  { question: 'お子様向けのメニューはありますか？' },
-]
-
-const accessOtherFAQ = [
-  { question: '送迎サービスはありますか？' },
-  { question: '駐車場はありますか？' },
-  { question: 'ペットの同伴は可能ですか？' },
-]
-
-export default function FAQPage() {
   return (
     <div className="ryokan-page">
       <Header />
@@ -52,30 +33,27 @@ export default function FAQPage() {
           ]}
         />
         <FAQIntroSection />
-        <FAQCategorySection
-          title="ご予約について"
-          icon="calendar"
-          variant="light"
-          items={reservationFAQ}
-        />
-        <FAQCategorySection
-          title="温泉・お部屋について"
-          icon="waves"
-          variant="alt"
-          items={onsenRoomFAQ}
-        />
-        <FAQCategorySection
-          title="お食事について"
-          icon="utensils"
-          variant="light"
-          items={cuisineFAQ}
-        />
-        <FAQCategorySection
-          title="アクセス・その他"
-          icon="map-pin"
-          variant="alt"
-          items={accessOtherFAQ}
-        />
+
+        {fetchError ? (
+          <section className="w-full" style={{ padding: '40px 80px 80px' }}>
+            <p role="alert">{fetchError}</p>
+          </section>
+        ) : sections.length > 0 ? (
+          sections.map((section) => (
+            <FAQCategorySection
+              key={section.key}
+              title={section.title}
+              icon={section.icon}
+              variant={section.variant}
+              items={section.items}
+            />
+          ))
+        ) : (
+          <section className="w-full" style={{ padding: '40px 80px 80px' }}>
+            <p>現在FAQを準備中です。</p>
+          </section>
+        )}
+
         <FAQContactSection />
         <CTASection />
       </main>

--- a/src/lib/faq.test.ts
+++ b/src/lib/faq.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { FaqItem } from "./microcms";
+import { groupFaqByCategory } from "./faq";
+
+const makeFaq = (overrides: Partial<FaqItem>): FaqItem => ({
+  id: "faq-id",
+  createdAt: "2026-02-01T00:00:00.000Z",
+  updatedAt: "2026-02-01T00:00:00.000Z",
+  question: "質問",
+  answer: "<p>回答</p>",
+  category: "reservation",
+  order: 1,
+  ...overrides,
+});
+
+test("groupFaqByCategory orders sections by predefined category sequence", () => {
+  const result = groupFaqByCategory([
+    makeFaq({ id: "1", category: "access_other", question: "Q4", order: 4 }),
+    makeFaq({ id: "2", category: "reservation", question: "Q1", order: 1 }),
+    makeFaq({ id: "3", category: "cuisine", question: "Q3", order: 3 }),
+    makeFaq({ id: "4", category: "onsen_room", question: "Q2", order: 2 }),
+  ]);
+
+  assert.deepEqual(
+    result.map((section) => section.key),
+    ["reservation", "onsen_room", "cuisine", "access_other"],
+  );
+});
+
+test("groupFaqByCategory maps unknown category into 'other' section", () => {
+  const result = groupFaqByCategory([
+    makeFaq({ category: "unknown-category", question: "未知カテゴリの質問" }),
+  ]);
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0]?.key, "other");
+  assert.equal(result[0]?.title, "その他のご質問");
+  assert.equal(result[0]?.items[0]?.question, "未知カテゴリの質問");
+});
+
+test("groupFaqByCategory strips HTML from answer text", () => {
+  const result = groupFaqByCategory([
+    makeFaq({ answer: "<p>回答<strong>テキスト</strong></p>" }),
+  ]);
+
+  assert.equal(result[0]?.items[0]?.answer, "回答 テキスト");
+});
+

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -1,0 +1,113 @@
+import type { FaqItem } from "./microcms";
+
+type FaqIcon = "calendar" | "waves" | "utensils" | "map-pin";
+type FaqVariant = "light" | "alt";
+
+type FaqCategoryKey =
+  | "reservation"
+  | "onsen_room"
+  | "cuisine"
+  | "access_other";
+
+type FaqCategorySection = {
+  key: FaqCategoryKey | "other";
+  title: string;
+  icon: FaqIcon;
+  variant: FaqVariant;
+  items: Array<{ question: string; answer?: string }>;
+};
+
+const CATEGORY_ALIASES: Record<string, FaqCategoryKey> = {
+  reservation: "reservation",
+  "ご予約について": "reservation",
+  onsen_room: "onsen_room",
+  onsenRoom: "onsen_room",
+  "温泉・お部屋について": "onsen_room",
+  cuisine: "cuisine",
+  "お食事について": "cuisine",
+  access_other: "access_other",
+  accessOther: "access_other",
+  "アクセス・その他": "access_other",
+};
+
+const CATEGORY_META: Record<
+  FaqCategoryKey | "other",
+  { title: string; icon: FaqIcon; variant: FaqVariant }
+> = {
+  reservation: {
+    title: "ご予約について",
+    icon: "calendar",
+    variant: "light",
+  },
+  onsen_room: {
+    title: "温泉・お部屋について",
+    icon: "waves",
+    variant: "alt",
+  },
+  cuisine: {
+    title: "お食事について",
+    icon: "utensils",
+    variant: "light",
+  },
+  access_other: {
+    title: "アクセス・その他",
+    icon: "map-pin",
+    variant: "alt",
+  },
+  other: {
+    title: "その他のご質問",
+    icon: "map-pin",
+    variant: "alt",
+  },
+};
+
+const CATEGORY_ORDER: Array<FaqCategoryKey | "other"> = [
+  "reservation",
+  "onsen_room",
+  "cuisine",
+  "access_other",
+  "other",
+];
+
+const stripHtml = (value: string): string =>
+  value
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const normalizeCategory = (value: string): FaqCategoryKey | "other" => {
+  const key = value.trim();
+  return CATEGORY_ALIASES[key] ?? "other";
+};
+
+export const groupFaqByCategory = (
+  items: FaqItem[],
+): FaqCategorySection[] => {
+  const grouped = new Map<FaqCategoryKey | "other", FaqCategorySection>();
+
+  for (const item of items) {
+    const key = normalizeCategory(item.category);
+    const meta = CATEGORY_META[key];
+    const existing = grouped.get(key) ?? {
+      key,
+      title: meta.title,
+      icon: meta.icon,
+      variant: meta.variant,
+      items: [],
+    };
+
+    existing.items.push({
+      question: item.question.trim(),
+      answer: stripHtml(item.answer),
+    });
+
+    grouped.set(key, existing);
+  }
+
+  const orderedSections = CATEGORY_ORDER.map((key) => grouped.get(key)).filter(
+    (section): section is FaqCategorySection => section !== undefined,
+  );
+
+  return orderedSections.filter((section) => section.items.length > 0);
+};


### PR DESCRIPTION
## Summary
- implement `/faq` with microCMS data source
- group FAQ entries by category and render in fixed section order
- handle unknown/malformed categories via fallback `other` section
- preserve contact/CTA flow on FAQ page
- add TDD tests for category grouping logic

## Scope
- `src/app/faq/page.tsx`
- `src/lib/faq.ts`
- `src/lib/faq.test.ts`

## Notes
- Stacked PR: base is #90 (`codex/16-news-detail-only`)

## Validation
- `node --test --import tsx src/lib/faq.test.ts`
- `node --test --import tsx src/lib/news-detail.test.ts`
- `node --test --import tsx src/lib/news-list-query.test.ts`
- `node --test --import tsx src/lib/microcms.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npm run build`

Refs #17
