### PR TITLE
feat(#18): connect top InfoSection to microCMS news

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,17 @@ import { OnsenSection } from '@/components/top/OnsenSection'
 import { CuisineSection } from '@/components/top/CuisineSection'
 import { StaySection } from '@/components/top/StaySection'
 import { InfoSection } from '@/components/top/InfoSection'
+import { getTopNewsItems, type TopNewsItem } from '@/lib/top-news'
 
-export default function Home() {
+export default async function Home() {
+  let topNewsItems: TopNewsItem[] = []
+
+  try {
+    topNewsItems = await getTopNewsItems()
+  } catch (error) {
+    console.error('Failed to fetch top news items', error)
+  }
+
   return (
     <div className="ryokan-page">
       <Header />
@@ -20,7 +29,7 @@ export default function Home() {
         <OnsenSection />
         <CuisineSection />
         <StaySection />
-        <InfoSection />
+        <InfoSection newsItems={topNewsItems} />
         <CTASection />
       </main>
       <Footer />

--- a/src/components/top/InfoSection.tsx
+++ b/src/components/top/InfoSection.tsx
@@ -1,14 +1,11 @@
 import Link from 'next/link'
+import type { TopNewsItem } from '@/lib/top-news'
 
-const newsItems = [
-  { date: '2025.02.15', title: '春の特別懐石「桜花」のご案内' },
-  { date: '2025.01.28', title: 'ミシュランガイド2025 二つ星を獲得いたしました' },
-  { date: '2025.01.10', title: '年末年始の営業について' },
-  { date: '2024.12.20', title: '冬の特別プラン「雪月花」のご案内' },
-  { date: '2024.11.15', title: '客室「月影」リニューアルのお知らせ' },
-]
+type InfoSectionProps = {
+  newsItems: TopNewsItem[]
+}
 
-export function InfoSection() {
+export function InfoSection({ newsItems }: InfoSectionProps) {
   return (
     <section
       className="flex w-full"
@@ -60,42 +57,57 @@ export function InfoSection() {
 
         {/* News list */}
         <ul className="flex flex-col" style={{ gap: 16, listStyle: 'none', padding: 0, margin: 0 }}>
-          {newsItems.map((item) => (
+          {newsItems.length > 0 ? (
+            newsItems.map((item) => (
+              <li
+                key={item.slug}
+                className="flex items-baseline"
+                style={{
+                  gap: 16,
+                  paddingBottom: 16,
+                  borderBottom: '1px solid var(--ryokan-soft-line)',
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: 'var(--font-accent)',
+                    fontSize: 13,
+                    fontWeight: 400,
+                    color: 'var(--ryokan-subtle)',
+                    letterSpacing: 1,
+                    flexShrink: 0,
+                  }}
+                >
+                  {item.date}
+                </span>
+                <p
+                  style={{
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 14,
+                    fontWeight: 300,
+                    color: 'var(--ryokan-dark)',
+                    letterSpacing: 1,
+                    margin: 0,
+                  }}
+                >
+                  {item.title}
+                </p>
+              </li>
+            ))
+          ) : (
             <li
-              key={item.date + item.title}
-              className="flex items-baseline"
               style={{
-                gap: 16,
-                paddingBottom: 16,
-                borderBottom: '1px solid var(--ryokan-soft-line)',
+                fontFamily: 'var(--font-body)',
+                fontSize: 14,
+                fontWeight: 300,
+                color: 'var(--ryokan-subtle)',
+                letterSpacing: 1,
+                paddingBottom: 8,
               }}
             >
-              <span
-                style={{
-                  fontFamily: 'var(--font-accent)',
-                  fontSize: 13,
-                  fontWeight: 400,
-                  color: 'var(--ryokan-subtle)',
-                  letterSpacing: 1,
-                  flexShrink: 0,
-                }}
-              >
-                {item.date}
-              </span>
-              <p
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontSize: 14,
-                  fontWeight: 300,
-                  color: 'var(--ryokan-dark)',
-                  letterSpacing: 1,
-                  margin: 0,
-                }}
-              >
-                {item.title}
-              </p>
+              お知らせは現在準備中です。
             </li>
-          ))}
+          )}
         </ul>
 
         {/* Link to all news */}

--- a/src/components/top/__tests__/InfoSection.test.tsx
+++ b/src/components/top/__tests__/InfoSection.test.tsx
@@ -1,31 +1,51 @@
 import { render, screen } from '@/test/utils'
 import { InfoSection } from '../InfoSection'
 
+const mockNewsItems = [
+  {
+    slug: 'spring-news',
+    date: '2026.02.20',
+    title: '春の特別懐石「桜花」のご案内',
+  },
+  {
+    slug: 'renewal-news',
+    date: '2026.02.10',
+    title: '客室「月影」リニューアルのお知らせ',
+  },
+]
+
 describe('InfoSection', () => {
   it('renders the NEWS english label', () => {
-    render(<InfoSection />)
+    render(<InfoSection newsItems={mockNewsItems} />)
     expect(screen.getByText('NEWS')).toBeInTheDocument()
   })
 
   it('renders the ACCESS english label', () => {
-    render(<InfoSection />)
+    render(<InfoSection newsItems={mockNewsItems} />)
     expect(screen.getByText('ACCESS')).toBeInTheDocument()
   })
 
-  it('renders news items with dates', () => {
-    render(<InfoSection />)
-    expect(screen.getByText('2025.02.15')).toBeInTheDocument()
+  it('renders news items from props with dates', () => {
+    render(<InfoSection newsItems={mockNewsItems} />)
+    expect(screen.getByText('2026.02.20')).toBeInTheDocument()
     expect(screen.getByText(/春の特別懐石/)).toBeInTheDocument()
+    expect(screen.getByText('2026.02.10')).toBeInTheDocument()
+    expect(screen.getByText(/客室「月影」リニューアル/)).toBeInTheDocument()
   })
 
   it('renders the address information', () => {
-    render(<InfoSection />)
+    render(<InfoSection newsItems={mockNewsItems} />)
     expect(screen.getByText(/神奈川県足柄下郡箱根町元箱根138/)).toBeInTheDocument()
   })
 
   it('renders a link to view all news', () => {
-    render(<InfoSection />)
+    render(<InfoSection newsItems={mockNewsItems} />)
     const link = screen.getByRole('link', { name: /一覧を見る/ })
     expect(link).toHaveAttribute('href', '/news')
+  })
+
+  it('renders fallback text when no news is provided', () => {
+    render(<InfoSection newsItems={[]} />)
+    expect(screen.getByText('お知らせは現在準備中です。')).toBeInTheDocument()
   })
 })

--- a/src/lib/top-news.test.ts
+++ b/src/lib/top-news.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { MicroCMSListResponse, MicroCMSQueries } from "microcms-js-sdk";
+
+import {
+  getTopNewsItems,
+  mapTopNewsItems,
+  TOP_NEWS_LIMIT,
+} from "./top-news";
+import type {
+  MicroCMSReadClient,
+  NewsContent,
+} from "./microcms";
+
+type GetListRequest = {
+  endpoint: string;
+  queries?: MicroCMSQueries;
+};
+
+type CallRecorder = {
+  calls: GetListRequest[];
+  client: MicroCMSReadClient;
+};
+
+const createRecorder = <T>(response: MicroCMSListResponse<T>): CallRecorder => {
+  const calls: GetListRequest[] = [];
+  const client: MicroCMSReadClient = {
+    getList: async <U = unknown>(request: GetListRequest) => {
+      calls.push(request);
+      return response as unknown as MicroCMSListResponse<U>;
+    },
+  };
+  return { calls, client };
+};
+
+test("mapTopNewsItems converts published date to top news display format", () => {
+  const items = mapTopNewsItems([
+    {
+      slug: "spring-news",
+      title: "春のお知らせ",
+      createdAt: "2026-02-01T10:00:00.000Z",
+      publishedAt: "2026-02-20T12:00:00.000Z",
+    },
+  ]);
+
+  assert.deepEqual(items, [
+    {
+      slug: "spring-news",
+      date: "2026.02.20",
+      title: "春のお知らせ",
+    },
+  ]);
+});
+
+test("mapTopNewsItems falls back to created date when published date is missing", () => {
+  const items = mapTopNewsItems([
+    {
+      slug: "draft-news",
+      title: "下書き記事",
+      createdAt: "2026-02-10T10:00:00.000Z",
+    },
+  ]);
+
+  assert.equal(items[0]?.date, "2026.02.10");
+});
+
+test("getTopNewsItems fetches latest news with top limit", async () => {
+  const recorder = createRecorder<NewsContent>({
+    contents: [
+      {
+        id: "news-1",
+        createdAt: "2026-02-10T00:00:00.000Z",
+        updatedAt: "2026-02-10T00:00:00.000Z",
+        publishedAt: "2026-02-12T00:00:00.000Z",
+        revisedAt: "2026-02-12T00:00:00.000Z",
+        title: "最新記事",
+        slug: "latest-news",
+        category: "イベント",
+        body: "<p>本文</p>",
+      },
+    ],
+    totalCount: 1,
+    limit: TOP_NEWS_LIMIT,
+    offset: 0,
+  });
+
+  const items = await getTopNewsItems(recorder.client);
+
+  assert.deepEqual(recorder.calls[0], {
+    endpoint: "news",
+    queries: {
+      limit: TOP_NEWS_LIMIT,
+      offset: 0,
+      orders: "-publishedAt",
+    },
+  });
+  assert.deepEqual(items, [
+    {
+      slug: "latest-news",
+      date: "2026.02.12",
+      title: "最新記事",
+    },
+  ]);
+});

--- a/src/lib/top-news.ts
+++ b/src/lib/top-news.ts
@@ -1,0 +1,34 @@
+import { getNewsList, type MicroCMSReadClient, type NewsContent } from "./microcms";
+
+export const TOP_NEWS_LIMIT = 5;
+
+export type TopNewsItem = {
+  slug: string;
+  date: string;
+  title: string;
+};
+
+type TopNewsSource = Pick<NewsContent, "slug" | "title"> & {
+  createdAt: string;
+  publishedAt?: string;
+};
+
+const toDisplayDate = (isoDate: string): string => {
+  const datePart = isoDate.slice(0, 10);
+  return datePart.replaceAll("-", ".");
+};
+
+export const mapTopNewsItems = (items: TopNewsSource[]): TopNewsItem[] => {
+  return items.map((item) => ({
+    slug: item.slug,
+    date: toDisplayDate(item.publishedAt ?? item.createdAt),
+    title: item.title,
+  }));
+};
+
+export const getTopNewsItems = async (
+  client?: MicroCMSReadClient,
+): Promise<TopNewsItem[]> => {
+  const response = await getNewsList({ page: 1, limit: TOP_NEWS_LIMIT }, client);
+  return mapTopNewsItems(response.contents as TopNewsSource[]);
+};


### PR DESCRIPTION
## Summary
- replace static top news list with microCMS-driven data
- fetch latest 5 news items on home page and pass to InfoSection
- add mapper/fetch helper (`src/lib/top-news.ts`) and tests
- update InfoSection tests to verify dynamic rendering and empty fallback

## Validation
- node --test --import tsx src/lib/top-news.test.ts
- npx vitest run src/components/top/__tests__/InfoSection.test.tsx
- npm run lint
- npm run typecheck
- npm run build
