### PR TITLE
feat(#185): HeroSection .pen 仕様完全実装

### DIFF
--- a/src/components/top/HeroSection.tsx
+++ b/src/components/top/HeroSection.tsx
@@ -16,7 +16,7 @@ export function HeroSection() {
       />
       <div
         className="absolute inset-0"
-        style={{ backgroundColor: '#1A150E77' }}
+        style={{ backgroundColor: 'var(--ryokan-hero-overlay)' }}
         aria-hidden="true"
       />
 
@@ -51,7 +51,7 @@ export function HeroSection() {
             fontFamily: 'var(--font-heading)',
             fontSize: 'var(--r-hero-title-size)',
             fontWeight: 'bold',
-            color: '#faf8f3',
+            color: 'var(--ryokan-text-on-dark)',
             letterSpacing: 'var(--r-hero-title-spacing)',
             lineHeight: 1.5,
             margin: 0,
@@ -78,11 +78,12 @@ export function HeroSection() {
 
         <Link
           href="#concept"
-          className="inline-flex items-center"
+          className="inline-flex items-center justify-center"
           style={{
             gap: 12,
             padding: '14px 40px',
-            border: '1px solid #D4C5A0CC',
+            border: '1px solid var(--ryokan-light-gold)',
+            borderColor: '#D4C5A0CC',
             backgroundColor: 'transparent',
             textDecoration: 'none',
             width: 'fit-content',
@@ -93,7 +94,7 @@ export function HeroSection() {
               fontFamily: 'var(--font-body)',
               fontSize: 13,
               fontWeight: 'normal',
-              color: '#D4C5A0',
+              color: 'var(--ryokan-light-gold)',
               letterSpacing: 3,
             }}
           >
@@ -109,7 +110,7 @@ export function HeroSection() {
           gap: 6,
           left: '50%',
           transform: 'translateX(-50%)',
-          bottom: 24,
+          bottom: 'var(--r-hero-scroll-bottom)',
         }}
       >
         <Mouse size={20} color="#D4C5A088" strokeWidth={1.5} />

--- a/src/components/top/__tests__/HeroSection.test.tsx
+++ b/src/components/top/__tests__/HeroSection.test.tsx
@@ -2,29 +2,35 @@ import { render, screen } from '@/test/utils'
 import { HeroSection } from '../HeroSection'
 
 describe('HeroSection', () => {
-  it('renders the main headline with ryokan name', () => {
+  it('renders the main headline', () => {
     render(<HeroSection />)
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('月瀬庵')
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent('湖と月、')
+    expect(heading).toHaveTextContent('そして静寂。')
   })
 
   it('renders the subtitle text', () => {
     render(<HeroSection />)
-    expect(screen.getByText('心を解くひととき')).toBeInTheDocument()
-  })
-
-  it('renders the English label TSUKISE-AN', () => {
-    render(<HeroSection />)
-    expect(screen.getByText('TSUKISE-AN')).toBeInTheDocument()
-  })
-
-  it('renders the scroll indicator', () => {
-    render(<HeroSection />)
-    expect(screen.getByText('Scroll')).toBeInTheDocument()
+    expect(
+      screen.getByText('芦ノ湖の湖面に映る月を眺める、全八室の離れ宿')
+    ).toBeInTheDocument()
   })
 
   it('renders the location label', () => {
     render(<HeroSection />)
     expect(screen.getByText('箱根 芦ノ湖畔')).toBeInTheDocument()
+  })
+
+  it('renders the CTA link with text and points to #concept', () => {
+    render(<HeroSection />)
+    expect(screen.getByText('宿を知る')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /宿を知る/ })
+    expect(link).toHaveAttribute('href', '#concept')
+  })
+
+  it('renders the scroll indicator', () => {
+    render(<HeroSection />)
+    expect(screen.getByText('Scroll')).toBeInTheDocument()
   })
 
   it('renders a background image with alt text "芦ノ湖畔の月瀬庵"', () => {
@@ -34,9 +40,15 @@ describe('HeroSection', () => {
     expect(img.tagName).toBe('IMG')
   })
 
-  it('renders the background image with src containing top-hero-main.png', () => {
+  it('renders the background image with src containing top-hero-main', () => {
     render(<HeroSection />)
     const img = screen.getByAltText('芦ノ湖畔の月瀬庵')
-    expect(img).toHaveAttribute('src', expect.stringContaining('top-hero-main.png'))
+    expect(img).toHaveAttribute('src', expect.stringContaining('top-hero-main'))
+  })
+
+  it('renders the hero overlay for readability', () => {
+    render(<HeroSection />)
+    const overlay = document.querySelector('[aria-hidden="true"]')
+    expect(overlay).toBeInTheDocument()
   })
 })

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -21,6 +21,7 @@
   --r-hero-content-y: 220px;
   --r-hero-content-gap: 32px;
   --r-hero-headline-w: 600px;
+  --r-hero-scroll-bottom: 55px;
 
   /* Subpage Hero */
   --r-subpage-hero-height: 480px;
@@ -140,6 +141,7 @@
     --r-hero-content-y: 160px;
     --r-hero-content-gap: 32px;
     --r-hero-headline-w: 420px;
+    --r-hero-scroll-bottom: 30px;
 
     --r-subpage-hero-height: 400px;
     --r-subpage-hero-title-size: 36px;
@@ -216,6 +218,7 @@
     --r-hero-content-y: 140px;
     --r-hero-content-gap: 24px;
     --r-hero-headline-w: 300px;
+    --r-hero-scroll-bottom: 50px;
 
     --r-subpage-hero-height: 320px;
     --r-subpage-hero-title-size: 28px;


### PR DESCRIPTION
## Summary
- HeroSection.tsx のハードコードされたカラー値をデザイントークン CSS 変数に置換 (`--ryokan-hero-overlay`, `--ryokan-text-on-dark`, `--ryokan-light-gold`)
- スクロールインジケーターの位置を .pen の絶対座標に準拠するレスポンシブ CSS 変数 `--r-hero-scroll-bottom` で制御 (PC: 55px / Tablet: 30px / Mobile: 50px)
- CTA ボタンに `justify-center` を追加し .pen の `justifyContent` 仕様に準拠
- テストを .pen 実コンテンツに更新 (見出し・サブタイトル・CTA テキスト)

## .pen 仕様との対応
| プロパティ | PC | Tablet | Mobile |
|---|---|---|---|
| Hero 高さ | 780px | 660px | 560px |
| タイトル fontSize | 56px | 44px | 32px |
| サブ fontSize | 16px | 14px | 13px |
| コンテンツ x/y | 100/220 | 60/160 | 24/140 |
| スクロール bottom | 55px | 30px | 50px |

## Test plan
- [x] HeroSection 8 テスト全パス
- [x] `npm run build` 成功
- [x] `npm run lint` エラーなし
- [x] `npm run typecheck` 成功

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)