### PR TITLE
feat(#187): RoomSection/OnsenSection .pen 仕様完全実装

### DIFF
--- a/src/components/top/OnsenSection.tsx
+++ b/src/components/top/OnsenSection.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from 'lucide-react'
 export function OnsenSection() {
   return (
     <section className="r-textimg-layout w-full overflow-hidden">
+      {/* Text Content (left on PC/Tablet, bottom on Mobile via column-reverse) */}
       <div
         className="flex flex-col justify-center"
         style={{
@@ -14,9 +15,17 @@ export function OnsenSection() {
           gap: 'var(--r-imgtext-gap)',
         }}
       >
-        <div className="flex items-center" style={{ gap: 16 }}>
+        {/* Section Label */}
+        <div
+          className="flex items-center"
+          style={{ gap: 'var(--r-imgtext-label-gap)' }}
+        >
           <span
-            style={{ width: 30, height: 1, backgroundColor: 'var(--ryokan-gold)' }}
+            style={{
+              width: 'var(--r-imgtext-label-line-w)',
+              height: 1,
+              backgroundColor: 'var(--ryokan-gold)',
+            }}
             aria-hidden="true"
           />
           <span
@@ -25,13 +34,14 @@ export function OnsenSection() {
               fontSize: 12,
               fontWeight: 500,
               color: 'var(--ryokan-gold)',
-              letterSpacing: 5,
+              letterSpacing: 'var(--r-imgtext-label-ls)',
             }}
           >
             ONSEN
           </span>
         </div>
 
+        {/* Title */}
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
@@ -48,12 +58,13 @@ export function OnsenSection() {
           湯処
         </h2>
 
+        {/* Description */}
         <p
+          className="r-onsen-desc"
           style={{
             fontFamily: 'var(--font-body)',
             fontSize: 'var(--r-body-md)',
             fontWeight: 300,
-            color: 'var(--ryokan-muted)',
             letterSpacing: 1,
             lineHeight: 2,
             margin: 0,
@@ -75,11 +86,12 @@ export function OnsenSection() {
           身体の芯から温まります。
         </p>
 
+        {/* Link */}
         <Link
           href="/onsen"
-          className="inline-flex items-center"
+          className="r-onsen-link inline-flex items-center"
           style={{
-            gap: 12,
+            gap: 'var(--r-imgtext-link-gap)',
             textDecoration: 'none',
             width: 'fit-content',
           }}
@@ -87,7 +99,7 @@ export function OnsenSection() {
           <span
             style={{
               fontFamily: 'var(--font-body)',
-              fontSize: 'var(--r-body-sm)',
+              fontSize: 14,
               fontWeight: 'normal',
               color: 'var(--ryokan-gold)',
               letterSpacing: 3,
@@ -99,6 +111,7 @@ export function OnsenSection() {
         </Link>
       </div>
 
+      {/* Image (right on PC/Tablet, top on Mobile via column-reverse) */}
       <div
         className="relative overflow-hidden"
         style={{
@@ -113,7 +126,7 @@ export function OnsenSection() {
           alt="月瀬庵の温泉"
           fill
           className="object-cover"
-          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 58.6vw"
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 800px"
         />
       </div>
     </section>

--- a/src/components/top/RoomSection.tsx
+++ b/src/components/top/RoomSection.tsx
@@ -19,7 +19,7 @@ export function RoomSection() {
           alt="月瀬庵の客室"
           fill
           className="object-cover"
-          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 58.6vw"
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 800px"
         />
       </div>
 
@@ -32,9 +32,17 @@ export function RoomSection() {
           gap: 'var(--r-imgtext-gap)',
         }}
       >
-        <div className="flex items-center" style={{ gap: 16 }}>
+        {/* Section Label */}
+        <div
+          className="flex items-center"
+          style={{ gap: 'var(--r-imgtext-label-gap)' }}
+        >
           <span
-            style={{ width: 30, height: 1, backgroundColor: 'var(--ryokan-gold)' }}
+            style={{
+              width: 'var(--r-imgtext-label-line-w)',
+              height: 1,
+              backgroundColor: 'var(--ryokan-gold)',
+            }}
             aria-hidden="true"
           />
           <span
@@ -43,13 +51,14 @@ export function RoomSection() {
               fontSize: 12,
               fontWeight: 500,
               color: 'var(--ryokan-gold)',
-              letterSpacing: 5,
+              letterSpacing: 'var(--r-imgtext-label-ls)',
             }}
           >
             ROOMS
           </span>
         </div>
 
+        {/* Title */}
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
@@ -66,6 +75,7 @@ export function RoomSection() {
           離れ
         </h2>
 
+        {/* Description */}
         <p
           style={{
             fontFamily: 'var(--font-body)',
@@ -91,11 +101,12 @@ export function RoomSection() {
           専用露天風呂を備えております。
         </p>
 
+        {/* Link */}
         <Link
           href="/rooms"
           className="inline-flex items-center"
           style={{
-            gap: 12,
+            gap: 'var(--r-imgtext-link-gap)',
             textDecoration: 'none',
             width: 'fit-content',
           }}
@@ -103,7 +114,7 @@ export function RoomSection() {
           <span
             style={{
               fontFamily: 'var(--font-body)',
-              fontSize: 'var(--r-body-sm)',
+              fontSize: 14,
               fontWeight: 'normal',
               color: 'var(--ryokan-light-gold)',
               letterSpacing: 3,
@@ -111,7 +122,13 @@ export function RoomSection() {
           >
             客室を見る
           </span>
-          <ArrowRight size={16} color="var(--ryokan-light-gold)" />
+          <ArrowRight
+            style={{
+              width: 'var(--r-imgtext-link-arrow)',
+              height: 'var(--r-imgtext-link-arrow)',
+            }}
+            color="var(--ryokan-light-gold)"
+          />
         </Link>
       </div>
     </section>

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -95,10 +95,15 @@
   --r-footer-nav-gap: 40px;
 
   /* ImgText / TextImg */
-  --r-imgtext-img-width: 58.6%;
+  --r-imgtext-img-width: 800px;
   --r-imgtext-padding: 80px;
   --r-imgtext-gap: 32px;
   --r-imgtext-img-h: auto;
+  --r-imgtext-label-line-w: 30px;
+  --r-imgtext-label-gap: 16px;
+  --r-imgtext-label-ls: 5px;
+  --r-imgtext-link-gap: 12px;
+  --r-imgtext-link-arrow: 16px;
 
   /* Cuisine / Stay */
   --r-center-px: 80px;
@@ -179,6 +184,11 @@
     --r-imgtext-img-width: 450px;
     --r-imgtext-padding: 40px 36px;
     --r-imgtext-gap: 24px;
+    --r-imgtext-label-line-w: 24px;
+    --r-imgtext-label-gap: 12px;
+    --r-imgtext-label-ls: 4px;
+    --r-imgtext-link-gap: 10px;
+    --r-imgtext-link-arrow: 14px;
 
     --r-center-px: 40px;
     --r-center-py: 80px;
@@ -269,9 +279,14 @@
     --r-footer-nav-gap: 12px;
 
     --r-imgtext-img-width: 100%;
-    --r-imgtext-padding: 32px;
+    --r-imgtext-padding: 32px 32px 60px 32px;
     --r-imgtext-gap: 32px;
     --r-imgtext-img-h: 280px;
+    --r-imgtext-label-line-w: 30px;
+    --r-imgtext-label-gap: 16px;
+    --r-imgtext-label-ls: 5px;
+    --r-imgtext-link-gap: 12px;
+    --r-imgtext-link-arrow: 16px;
 
     --r-center-px: 24px;
     --r-center-py: 60px;
@@ -342,6 +357,30 @@
   }
   .r-grid-row {
     flex-direction: column;
+  }
+}
+
+/* ===========================================
+   Onsen Section Responsive Overrides
+   (Tablet desc color differs from PC/Mobile)
+   =========================================== */
+
+/* PC & Mobile: desc color = muted (#4A4035) */
+.r-onsen-desc {
+  color: var(--ryokan-muted);
+}
+
+/* Tablet: desc color = secondary (#6B5D4F) */
+@media (min-width: 768px) and (max-width: 1023px) {
+  .r-onsen-desc {
+    color: var(--ryokan-secondary);
+  }
+}
+
+/* Mobile: Onsen link font-size = 13px (vs Room's 14px) */
+@media (max-width: 767px) {
+  .r-onsen-link span {
+    font-size: 13px;
   }
 }
 


### PR DESCRIPTION
## Summary
- RoomSection (ImgText) と OnsenSection (TextImg) を .pen デザイン仕様に完全準拠
- PC/Tablet/Mobile 3ビューポートのレスポンシブ CSS 変数を追加（ラベル、リンク）
- Onsen セクション固有のレスポンシブオーバーライド（Tablet 説明文色、Mobile リンクサイズ）

## Changes

### CSS Variables (`ryokan-responsive.css`)
- `--r-imgtext-img-width`: PC を `58.6%` から `800px` に修正（.pen 仕様）
- `--r-imgtext-padding`: Mobile を `32px` から `32px 32px 60px 32px` に修正（下部余白増）
- 新規追加: `--r-imgtext-label-line-w`, `--r-imgtext-label-gap`, `--r-imgtext-label-ls`
- 新規追加: `--r-imgtext-link-gap`, `--r-imgtext-link-arrow`
- Onsen 固有: `.r-onsen-desc` (Tablet: #6B5D4F), `.r-onsen-link span` (Mobile: 13px)

### Components
- `RoomSection.tsx`: ハードコード値を CSS 変数に置換、`sizes` 属性修正
- `OnsenSection.tsx`: 同上 + `.r-onsen-desc` / `.r-onsen-link` クラス追加

## .pen Design Spec Mapping

| Property | PC | Tablet | Mobile |
|---|---|---|---|
| Image width | 800px | 450px | 100% |
| Content padding | 80px | 40px 36px | 32px 32px 60px 32px |
| Content gap | 32px | 24px | 32px |
| Label line width | 30px | 24px | 30px |
| Label gap | 16px | 12px | 16px |
| Label letter-spacing | 5px | 4px | 5px |
| Link gap | 12px | 10px | 12px |
| Link arrow | 16px | 14px | 16px |

## Test plan
- [x] `npm run build` 成功
- [x] `tsc --noEmit` パス
- [x] `next lint` パス
- [ ] ブラウザで PC/Tablet/Mobile 各ビューポート確認
- [ ] RoomSection: 暗背景 (#2C2418) + 明テキスト
- [ ] OnsenSection: 明背景 (#EEEBE3) + 暗テキスト
- [ ] Mobile: 画像上 + テキスト下（両セクション）

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)