### PR TITLE
feat(#189): StaySection .pen 仕様完全実装

### DIFF
--- a/src/components/top/StaySection.tsx
+++ b/src/components/top/StaySection.tsx
@@ -21,7 +21,7 @@ const timelineMorning = [
 
 function TimelineCard({ hour, title, desc, image }: { hour: string; title: string; desc: string; image: string }) {
   return (
-    <div className="flex flex-1 flex-col items-center" style={{ gap: 20, paddingTop: 8 }}>
+    <div className="stay-card">
       <span
         style={{
           fontFamily: 'var(--font-accent)',
@@ -37,7 +37,7 @@ function TimelineCard({ hour, title, desc, image }: { hour: string; title: strin
         className="relative w-full overflow-hidden"
         style={{ height: 'var(--r-timeline-img-h)' }}
       >
-        <Image src={image} alt={title} fill className="object-cover" sizes="(max-width: 767px) 100vw, 25vw" />
+        <Image src={image} alt={title} fill className="object-cover" sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 25vw" />
       </div>
       <h3
         style={{
@@ -76,12 +76,12 @@ export function StaySection() {
       style={{
         padding: 'var(--r-center-py) var(--r-center-px)',
         gap: 'var(--r-stay-gap)',
-        backgroundColor: 'var(--ryokan-bg)',
         backgroundImage: 'url(/images/top-stay-bg.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
       }}
     >
+      {/* Section Label */}
       <div className="flex items-center" style={{ gap: 20 }}>
         <span
           style={{ width: 60, height: 1, backgroundColor: 'var(--ryokan-light-gold)' }}
@@ -104,6 +104,7 @@ export function StaySection() {
         />
       </div>
 
+      {/* Section Title */}
       <h2
         style={{
           fontFamily: 'var(--font-heading)',
@@ -118,54 +119,56 @@ export function StaySection() {
         月瀬庵での過ごし方
       </h2>
 
-      <div className="flex w-full flex-col" style={{ gap: 24 }}>
-        <div className="r-grid-row w-full" style={{ gap: 'var(--r-timeline-gap)' }}>
-          {timelineAfternoon.map((item) => (
-            <TimelineCard key={item.hour} {...item} />
-          ))}
-        </div>
+      {/* Timeline Afternoon: PC=4col, Tablet=2col, Mobile=1col */}
+      <div className="stay-grid stay-grid--4">
+        {timelineAfternoon.map((item) => (
+          <TimelineCard key={item.hour} {...item} />
+        ))}
+      </div>
 
-        <div className="r-grid-row w-full" style={{ gap: 'var(--r-timeline-gap)' }}>
-          {timelineEvening.map((item) => (
-            <TimelineCard key={item.hour} {...item} />
-          ))}
-        </div>
+      {/* Timeline Evening: PC=3col, Tablet=2col, Mobile=1col */}
+      <div className="stay-grid stay-grid--3">
+        {timelineEvening.map((item) => (
+          <TimelineCard key={item.hour} {...item} />
+        ))}
+      </div>
 
-        <div className="flex w-full items-center justify-center" style={{ gap: 24 }}>
-          <span
-            style={{
-              width: 'var(--r-divider-w)',
-              height: 1,
-              backgroundColor: 'var(--ryokan-light-gold)',
-            }}
-            aria-hidden="true"
-          />
-          <span
-            style={{
-              fontFamily: 'var(--font-heading)',
-              fontSize: 14,
-              fontWeight: 'normal',
-              color: 'var(--ryokan-subtle)',
-              letterSpacing: 8,
-            }}
-          >
-            翌 朝
-          </span>
-          <span
-            style={{
-              width: 'var(--r-divider-w)',
-              height: 1,
-              backgroundColor: 'var(--ryokan-light-gold)',
-            }}
-            aria-hidden="true"
-          />
-        </div>
+      {/* Divider: 翌 朝 */}
+      <div className="flex w-full items-center justify-center" style={{ gap: 'var(--r-divider-gap)' }}>
+        <span
+          style={{
+            width: 'var(--r-divider-w)',
+            height: 1,
+            backgroundColor: 'var(--ryokan-light-gold)',
+          }}
+          aria-hidden="true"
+        />
+        <span
+          style={{
+            fontFamily: 'var(--font-heading)',
+            fontSize: 14,
+            fontWeight: 'normal',
+            color: 'var(--ryokan-subtle)',
+            letterSpacing: 8,
+          }}
+        >
+          翌 朝
+        </span>
+        <span
+          style={{
+            width: 'var(--r-divider-w)',
+            height: 1,
+            backgroundColor: 'var(--ryokan-light-gold)',
+          }}
+          aria-hidden="true"
+        />
+      </div>
 
-        <div className="r-grid-row w-full" style={{ gap: 'var(--r-timeline-gap)' }}>
-          {timelineMorning.map((item) => (
-            <TimelineCard key={item.hour} {...item} />
-          ))}
-        </div>
+      {/* Timeline Morning: PC=3col, Tablet=2col, Mobile=1col */}
+      <div className="stay-grid stay-grid--3">
+        {timelineMorning.map((item) => (
+          <TimelineCard key={item.hour} {...item} />
+        ))}
       </div>
     </section>
   )

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -119,6 +119,7 @@
   --r-dish-h: 300px;
   --r-timeline-img-h: 200px;
   --r-divider-w: 120px;
+  --r-divider-gap: 24px;
   --r-stay-gap: 60px;
 
   /* Info */
@@ -311,6 +312,7 @@
     --r-dish-h: 200px;
     --r-timeline-img-h: 160px;
     --r-divider-w: 60px;
+    --r-divider-gap: 12px;
     --r-stay-gap: 32px;
 
     --r-info-padding: 32px;
@@ -383,6 +385,51 @@
   }
   .r-grid-row {
     flex-direction: column;
+  }
+}
+
+/* ===========================================
+   Stay Section Timeline Grid
+   PC: 4col/3col | Tablet: 2col | Mobile: 1col
+   =========================================== */
+
+.stay-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding-top: 8px;
+  min-width: 0;
+}
+
+/* PC (default): CSS Grid */
+.stay-grid {
+  display: grid;
+  width: 100%;
+  gap: var(--r-timeline-gap);
+}
+
+.stay-grid--4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.stay-grid--3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+/* Tablet: 2 columns */
+@media (max-width: 1023px) {
+  .stay-grid--4,
+  .stay-grid--3 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Mobile: 1 column */
+@media (max-width: 767px) {
+  .stay-grid--4,
+  .stay-grid--3 {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- StaySection のグリッドレイアウトを .pen デザイン仕様に完全準拠させた
- flexbox ベースの `r-grid-row` から CSS Grid (`.stay-grid`) に移行し、PC(4col/3col), Tablet(2col), Mobile(1col) のレスポンシブカラムを正確に再現
- 「翌 朝」ディバイダーの gap を新規 CSS 変数 `--r-divider-gap` で制御（PC/Tablet: 24px, Mobile: 12px）

## Changes
| File | Description |
|------|-------------|
| `src/components/top/StaySection.tsx` | CSS Grid 化、Image sizes 属性にTabletブレークポイント追加、不要な backgroundColor 削除 |
| `src/lib/css/ryokan-responsive.css` | `.stay-grid`, `.stay-card` クラス追加、`--r-divider-gap` 変数追加 |

## .pen Design Spec Mapping
| Property | PC | Tablet | Mobile |
|----------|-----|--------|--------|
| padding | 100px 80px | 80px 40px | 60px 24px |
| gap (section) | 60px | 48px | 32px |
| grid columns (afternoon) | 4 | 2 | 1 |
| grid columns (evening/morning) | 3 | 2 | 1 |
| card gap | 32px | 16px | 32px |
| image height | 200px | 200px | 160px |
| divider line width | 120px | 120px | 60px |
| divider gap | 24px | 24px | 12px |
| title fontSize | 32px | 32px | 24px |

## Test plan
- [x] `npm run build` -- success
- [x] `npx tsc --noEmit` -- no type errors
- [x] `npx next lint` -- no warnings or errors
- [ ] Visual verification at PC (1440px), Tablet (768px), Mobile (375px) widths

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)