### PR TITLE
feat(#188): CuisineSection .pen 仕様完全実装

### DIFF
--- a/src/components/top/CuisineSection.tsx
+++ b/src/components/top/CuisineSection.tsx
@@ -13,12 +13,12 @@ export function CuisineSection() {
       style={{
         padding: 'var(--r-center-py) var(--r-center-px)',
         gap: 'var(--r-center-gap)',
-        backgroundColor: 'var(--ryokan-dark)',
         backgroundImage: 'url(/images/top-cuisine-bg.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
       }}
     >
+      {/* Section Label: line - CUISINE - line */}
       <div className="flex items-center" style={{ gap: 20 }}>
         <span
           style={{ width: 60, height: 1, backgroundColor: 'var(--ryokan-gold)' }}
@@ -41,6 +41,7 @@ export function CuisineSection() {
         />
       </div>
 
+      {/* Section Title */}
       <h2
         style={{
           fontFamily: 'var(--font-heading)',
@@ -55,16 +56,18 @@ export function CuisineSection() {
         旬を紡ぐ、月替わり懐石
       </h2>
 
+      {/* Description */}
       <p
         style={{
           fontFamily: 'var(--font-body)',
-          fontSize: 'var(--r-body-md)',
+          fontSize: 'var(--r-cuisine-desc-size)',
           fontWeight: 300,
           color: 'var(--ryokan-text-subtle)',
           letterSpacing: 1,
           lineHeight: 2,
           textAlign: 'center',
-          maxWidth: 600,
+          width: 'var(--r-cuisine-desc-width)',
+          maxWidth: '100%',
           margin: 0,
         }}
       >
@@ -75,11 +78,12 @@ export function CuisineSection() {
         ミシュラン二つ星の評価を賜りました。
       </p>
 
-      <div className="r-grid-row w-full" style={{ gap: 'var(--r-grid-gap)' }}>
+      {/* Dish Card Grid: 3-col PC / 2+1 Tablet / 1-col Mobile */}
+      <div className="r-cuisine-grid">
         {dishes.map((dish) => (
           <div
             key={dish.title}
-            className="flex flex-1 flex-col items-center"
+            className="flex flex-col items-center"
             style={{ gap: 16, paddingBottom: 24 }}
           >
             <div
@@ -91,7 +95,7 @@ export function CuisineSection() {
                 alt={dish.title}
                 fill
                 className="object-cover"
-                sizes="(max-width: 767px) 100vw, 33vw"
+                sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw"
               />
             </div>
             <h3

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -122,6 +122,10 @@
   --r-divider-gap: 24px;
   --r-stay-gap: 60px;
 
+  /* Cuisine-specific */
+  --r-cuisine-desc-size: 15px;
+  --r-cuisine-desc-width: 600px;
+
   /* Info */
   --r-info-padding: 80px;
   --r-info-gap: 60px;
@@ -208,6 +212,10 @@
     --r-timeline-gap: 16px;
     --r-dish-h: 220px;
     --r-stay-gap: 48px;
+
+    /* Cuisine-specific (Tablet: desc stays 15px, width 600px) */
+    --r-cuisine-desc-size: 15px;
+    --r-cuisine-desc-width: 600px;
 
     --r-info-padding: 48px;
     --r-info-gap: 40px;
@@ -314,6 +322,10 @@
     --r-divider-w: 60px;
     --r-divider-gap: 12px;
     --r-stay-gap: 32px;
+
+    /* Cuisine-specific (Mobile: desc 14px, full width) */
+    --r-cuisine-desc-size: 14px;
+    --r-cuisine-desc-width: 100%;
 
     --r-info-padding: 32px;
     --r-info-gap: 32px;
@@ -429,6 +441,29 @@
 @media (max-width: 767px) {
   .stay-grid--4,
   .stay-grid--3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Cuisine Grid: 3-col (PC) / 2+1 (Tablet) / 1-col (Mobile)
+   =========================================== */
+
+.r-cuisine-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--r-grid-gap);
+  width: 100%;
+}
+
+@media (max-width: 1023px) {
+  .r-cuisine-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .r-cuisine-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- CuisineSection を .pen デザイン仕様に完全準拠させる実装
- Flex レイアウトから CSS Grid へ移行し、Tablet の 2+1 レイアウト（.pen SSOT）を正確に再現
- Cuisine 専用 CSS 変数（`--r-cuisine-desc-size`, `--r-cuisine-desc-width`）を追加し、Tablet でのフォントサイズ差異を修正

## Changes

### CuisineSection.tsx
- `r-grid-row`（flex）→ `r-cuisine-grid`（CSS Grid）に置換
- `--r-body-md` → `--r-cuisine-desc-size` で Tablet desc fontSize 15px を正確に反映
- `maxWidth: 600` → `width: var(--r-cuisine-desc-width)` で Mobile 時に full-width
- 不要な `backgroundColor` fallback を削除（背景画像でカバー）
- Image `sizes` prop を Tablet 50vw に更新

### ryokan-responsive.css
- `--r-cuisine-desc-size`: PC 15px / Tablet 15px / Mobile 14px
- `--r-cuisine-desc-width`: PC 600px / Tablet 600px / Mobile 100%
- `.r-cuisine-grid` クラス: PC `repeat(3, 1fr)` / Tablet `repeat(2, 1fr)` / Mobile `1fr`

## .pen 仕様対応表

| Property | PC (.pen) | Tablet (.pen) | Mobile (.pen) | Implementation |
|---|---|---|---|---|
| Section padding | [100, 80] | [80, 40] | [60, 24] | `--r-center-py/px` |
| Section gap | 60 | 48 | 40 | `--r-center-gap` |
| Title fontSize | 32 | 32 | 24 | `--r-title-md` |
| Desc fontSize | 15 | 15 | 14 | `--r-cuisine-desc-size` |
| Desc width | 600 | 600 | fill | `--r-cuisine-desc-width` |
| Grid columns | 3 | 2+1 | 1 | `.r-cuisine-grid` |
| Grid gap | 24 | 16 | 24 | `--r-grid-gap` |
| Dish img height | 300 | 220 | 200 | `--r-dish-h` |

## Test plan
- [x] `npm run build` - 成功
- [x] `npm run lint` - 警告/エラーなし
- [x] `npm run typecheck` - パス
- [x] `vitest run CuisineSection` - 10/10 テスト通過

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)