### PR TITLE
feat(#190): InfoSection .pen 仕様完全実装

### DIFF
--- a/src/components/top/InfoSection.tsx
+++ b/src/components/top/InfoSection.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
-import { ArrowRight } from 'lucide-react'
+import { ArrowRight, Car, TrainFront } from 'lucide-react'
 import type { TopNewsItem } from '@/lib/top-news'
 
 type InfoSectionProps = {
@@ -19,6 +19,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
     >
       {/* News Column */}
       <div className="flex flex-1 flex-col" style={{ gap: 32 }}>
+        {/* Section Label */}
         <div className="flex items-center" style={{ gap: 16 }}>
           <span
             style={{ width: 30, height: 1, backgroundColor: 'var(--ryokan-gold)' }}
@@ -37,6 +38,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
           </span>
         </div>
 
+        {/* Section Title */}
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
@@ -51,25 +53,27 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
         </h2>
 
         {/* News list */}
-        <ul className="flex flex-col" style={{ gap: 16, listStyle: 'none', padding: 0, margin: 0 }}>
+        <ul
+          className="flex flex-col w-full"
+          style={{ listStyle: 'none', padding: 0, margin: 0 }}
+        >
           {newsItems.length > 0 ? (
             newsItems.map((item) => (
               <li
                 key={item.slug}
-                className="flex items-baseline"
+                className="flex items-center w-full"
                 style={{
-                  gap: 16,
-                  paddingBottom: 16,
-                  borderBottom: '1px solid var(--ryokan-soft-line)',
+                  gap: 24,
+                  padding: '16px 0',
+                  borderBottom: '1px solid var(--ryokan-light-gold)',
                 }}
               >
                 <span
                   style={{
                     fontFamily: 'var(--font-accent)',
                     fontSize: 'var(--r-body-xs)',
-                    fontWeight: 400,
+                    fontWeight: 500,
                     color: 'var(--ryokan-subtle)',
-                    letterSpacing: 1,
                     flexShrink: 0,
                   }}
                 >
@@ -80,8 +84,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
                     fontFamily: 'var(--font-body)',
                     fontSize: 'var(--r-body-sm)',
                     fontWeight: 300,
-                    color: 'var(--ryokan-dark)',
-                    letterSpacing: 1,
+                    color: 'var(--ryokan-muted)',
                     margin: 0,
                   }}
                 >
@@ -105,6 +108,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
           )}
         </ul>
 
+        {/* View All Link */}
         <Link
           href="/news"
           className="inline-flex items-center"
@@ -130,7 +134,8 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
       </div>
 
       {/* Access Column */}
-      <div className="flex flex-1 flex-col" style={{ gap: 24 }}>
+      <div className="r-info-access-col flex flex-col" style={{ gap: 24 }}>
+        {/* Section Label */}
         <div className="flex items-center" style={{ gap: 16 }}>
           <span
             style={{ width: 30, height: 1, backgroundColor: 'var(--ryokan-gold)' }}
@@ -149,6 +154,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
           </span>
         </div>
 
+        {/* Section Title */}
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
@@ -162,7 +168,8 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
           アクセス
         </h2>
 
-        <div className="flex flex-col" style={{ gap: 24 }}>
+        {/* Address & Transport Info */}
+        <div className="flex flex-col w-full" style={{ gap: 24 }}>
           <p
             style={{
               fontFamily: 'var(--font-body)',
@@ -184,14 +191,16 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
             FAX&nbsp;&nbsp;0460-83-XXXX
           </p>
 
+          {/* Access Methods */}
           <div className="flex flex-col" style={{ gap: 12 }}>
             <div className="flex items-center" style={{ gap: 12 }}>
+              <Car size={16} color="var(--ryokan-gold)" aria-hidden="true" />
               <span
                 style={{
                   fontFamily: 'var(--font-body)',
                   fontSize: 'var(--r-body-xs)',
                   fontWeight: 300,
-                  color: 'var(--ryokan-muted)',
+                  color: 'var(--ryokan-secondary)',
                   letterSpacing: 1,
                 }}
               >
@@ -199,12 +208,13 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
               </span>
             </div>
             <div className="flex items-center" style={{ gap: 12 }}>
+              <TrainFront size={16} color="var(--ryokan-gold)" aria-hidden="true" />
               <span
                 style={{
                   fontFamily: 'var(--font-body)',
                   fontSize: 'var(--r-body-xs)',
                   fontWeight: 300,
-                  color: 'var(--ryokan-muted)',
+                  color: 'var(--ryokan-secondary)',
                   letterSpacing: 1,
                 }}
               >
@@ -214,6 +224,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
           </div>
         </div>
 
+        {/* Map */}
         <div
           className="relative w-full overflow-hidden"
           style={{
@@ -227,7 +238,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
             alt="月瀬庵へのアクセスマップ"
             fill
             className="object-cover"
-            sizes="560px"
+            sizes="(min-width: 1024px) 560px, 100vw"
           />
         </div>
       </div>

--- a/src/components/top/__tests__/InfoSection.test.tsx
+++ b/src/components/top/__tests__/InfoSection.test.tsx
@@ -48,4 +48,21 @@ describe('InfoSection', () => {
     render(<InfoSection newsItems={[]} />)
     expect(screen.getByText('お知らせは現在準備中です。')).toBeInTheDocument()
   })
+
+  it('renders access methods with transport info', () => {
+    render(<InfoSection newsItems={mockNewsItems} />)
+    expect(screen.getByText(/お車で：東名高速/)).toBeInTheDocument()
+    expect(screen.getByText(/電車で：箱根湯本駅/)).toBeInTheDocument()
+  })
+
+  it('renders TEL and FAX numbers', () => {
+    render(<InfoSection newsItems={mockNewsItems} />)
+    expect(screen.getByText(/0460-83-XXXX/)).toBeInTheDocument()
+  })
+
+  it('renders the map image with alt text', () => {
+    render(<InfoSection newsItems={mockNewsItems} />)
+    const mapImg = screen.getByAltText('月瀬庵へのアクセスマップ')
+    expect(mapImg).toBeInTheDocument()
+  })
 })

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -354,6 +354,12 @@
   flex-direction: row;
 }
 
+/* Info access column: fixed 560px on PC, full on tablet/mobile */
+.r-info-access-col {
+  width: 560px;
+  flex-shrink: 0;
+}
+
 /* CTA buttons: row → column on mobile */
 .r-cta-btns {
   display: flex;
@@ -369,6 +375,10 @@
 @media (max-width: 1023px) {
   .r-info-layout {
     flex-direction: column;
+  }
+  .r-info-access-col {
+    width: 100%;
+    flex-shrink: 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- InfoSection コンポーネントを .pen デザイン仕様に完全準拠させる
- PC/Tablet/Mobile 全3ビューポートの差分を正確に反映
- ニュースリスト・アクセス情報の細部を .pen 仕様に合わせて修正

## Changes

### InfoSection.tsx
- ニュースアイテム: `items-baseline` → `items-center`、gap 16→24px、date fontWeight 400→500
- ニューステキスト色: `ryokan-dark` (#2C2418) → `ryokan-muted` (#4A4035)
- ボーダー色: `ryokan-soft-line` (alpha付き) → `ryokan-light-gold` (#D4C5A0)
- アクセス方法アイコン: `Car`・`TrainFront` lucide アイコン追加（gold色）
- アクセス方法テキスト色: `ryokan-muted` → `ryokan-secondary` (#6B5D4F)
- アクセスカラム: `flex-1` → `r-info-access-col` (PC: 560px固定)
- Image sizes 属性: `560px` → `(min-width: 1024px) 560px, 100vw`

### ryokan-responsive.css
- `.r-info-access-col` クラス追加: PC=560px固定、Tablet/Mobile=100%

### InfoSection.test.tsx
- アクセス方法テスト追加（車・電車テキスト）
- TEL/FAX番号レンダリングテスト追加
- 地図画像 alt テスト追加

## .pen Spec Reference
| Property | PC | Tablet | Mobile |
|---|---|---|---|
| Layout | horizontal (2col) | vertical (1col) | vertical (1col) |
| Padding | 80px | 48px | 32px |
| Gap | 60px | 40px | 32px |
| Access col width | 560px | fill | fill |
| Map height | 200px | 200px | 180px |

## Test plan
- [x] `npx tsc --noEmit` — TypeScript compilation passes
- [x] `npx vitest run InfoSection.test.tsx` — 9/9 tests pass
- [x] `npx next lint` — No ESLint warnings or errors

Closes #190

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)