### PR TITLE
feat(#199): implement access page to .pen specs

### DIFF
--- a/src/app/access/page.tsx
+++ b/src/app/access/page.tsx
@@ -13,7 +13,11 @@ export default function AccessPage() {
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="アクセス" labelEn="ACCESS" />
+        <PageHero
+          title="アクセス"
+          labelEn="ACCESS"
+          subtitle="箱根・芦ノ湖畔の隠れ宿へ"
+        />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/components/access/AccessMethodsSection.tsx
+++ b/src/components/access/AccessMethodsSection.tsx
@@ -1,21 +1,32 @@
-const accessMethods = [
+import { TrainFront, Car, Bus } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+type AccessMethod = {
+  icon: LucideIcon
+  title: string
+  body: string
+}
+
+const accessMethods: AccessMethod[] = [
   {
-    title: 'お車でお越しの方',
-    description: '東名高速 御殿場ICより約40分\n無料駐車場あり（8台）',
-  },
-  {
+    icon: TrainFront,
     title: '電車でお越しの方',
-    description:
-      '箱根湯本駅よりバス30分「元箱根港」下車、送迎車5分\n※送迎要予約',
+    body: '新宿駅\n↓ 小田急ロマンスカー（約85分）\n箱根湯本駅\n↓ 箱根登山バス（約40分）\n元箱根港\n↓ 送迎車（約5分）\n月瀬庵',
   },
   {
-    title: 'バスでお越しの方',
-    description: '小田原駅より箱根登山バス「元箱根港」行き約50分',
+    icon: Car,
+    title: 'お車でお越しの方',
+    body: '東名高速道路\n↓ 御殿場IC（約10分）\n箱根スカイライン\n↓ 芦ノ湖方面（約20分）\n\n駐車場：8台（無料）',
   },
   {
+    icon: Bus,
     title: '送迎サービス',
-    description:
-      '元箱根港・箱根湯本駅より送迎あり（要予約）\nお電話にてお申し付けください',
+    body: '箱根湯本駅・元箱根港から\n無料送迎を承っております。\n\nご予約時にお申し付けください。\n\n運行時間：14:00〜18:00',
+  },
+  {
+    icon: Bus,
+    title: 'バスでお越しの方',
+    body: '小田原駅より箱根登山バス\n「元箱根」バス停下車（約60分）\n送迎バスで約5分',
   },
 ]
 
@@ -25,7 +36,7 @@ export function AccessMethodsSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '60px 80px',
+        padding: 'var(--r-access-methods-py) var(--r-access-methods-px)',
         gap: 40,
       }}
     >
@@ -42,52 +53,61 @@ export function AccessMethodsSection() {
         アクセス方法
       </h2>
 
-      {/* Access method cards row */}
-      <div
-        className="grid w-full"
-        style={{
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          gap: 32,
-        }}
-      >
-        {accessMethods.map((method) => (
-          <div
-            key={method.title}
-            data-testid="access-method-card"
-            className="flex flex-col"
-            style={{
-              backgroundColor: 'var(--ryokan-light-bg-alt, #F0EBE0)',
-              borderRadius: 4,
-              padding: '32px 24px',
-              gap: 16,
-            }}
-          >
-            <h3
+      {/* Access method cards */}
+      <div className="r-access-methods-grid w-full">
+        {accessMethods.map((method) => {
+          const IconComponent = method.icon
+          return (
+            <div
+              key={method.title}
+              data-testid="access-method-card"
+              className="flex flex-col items-center"
               style={{
-                fontFamily: 'var(--font-body)',
-                fontSize: 16,
-                fontWeight: 500,
-                color: 'var(--ryokan-dark, #2C2418)',
-                letterSpacing: 1,
+                backgroundColor: 'var(--ryokan-info-bg, #F0EBE0)',
+                borderRadius: 4,
+                padding: '32px 28px',
+                gap: 20,
               }}
             >
-              {method.title}
-            </h3>
-            <p
-              style={{
-                fontFamily: 'var(--font-body)',
-                fontSize: 14,
-                fontWeight: 300,
-                color: 'var(--ryokan-secondary, #6B5D4F)',
-                letterSpacing: 1,
-                lineHeight: 2.0,
-                whiteSpace: 'pre-line',
-              }}
-            >
-              {method.description}
-            </p>
-          </div>
-        ))}
+              {/* Icon */}
+              <IconComponent
+                size={32}
+                style={{ color: 'var(--ryokan-gold, #8B6914)' }}
+                strokeWidth={1.5}
+                aria-hidden="true"
+              />
+
+              {/* Title */}
+              <h3
+                className="text-center"
+                style={{
+                  fontFamily: 'var(--font-heading)',
+                  fontSize: 16,
+                  fontWeight: 600,
+                  color: 'var(--ryokan-dark, #2C2418)',
+                  letterSpacing: 2,
+                }}
+              >
+                {method.title}
+              </h3>
+
+              {/* Body text */}
+              <p
+                className="w-full text-center"
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 13,
+                  fontWeight: 300,
+                  color: 'var(--ryokan-secondary, #6B5D4F)',
+                  lineHeight: 2.0,
+                  whiteSpace: 'pre-line',
+                }}
+              >
+                {method.body}
+              </p>
+            </div>
+          )
+        })}
       </div>
     </section>
   )

--- a/src/components/access/AddressSection.tsx
+++ b/src/components/access/AddressSection.tsx
@@ -1,27 +1,53 @@
-import { SectionLabel } from '@/components/shared/SectionLabel/SectionLabel'
-
 export function AddressSection() {
   return (
     <section
-      className="flex w-full flex-col items-center"
+      className="r-access-addr flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '80px 200px',
+        padding: 'var(--r-access-addr-py) var(--r-access-addr-px)',
         gap: 40,
       }}
     >
-      {/* Section label */}
-      <SectionLabel english="ADDRESS" />
+      {/* Section label — LOCATION */}
+      <div className="flex items-center" style={{ gap: 20 }}>
+        <span
+          className="block"
+          style={{
+            width: 40,
+            height: 1,
+            backgroundColor: 'var(--ryokan-light-gold, #D4C5A0)',
+          }}
+        />
+        <span
+          style={{
+            fontFamily: 'var(--font-accent)',
+            fontSize: 13,
+            fontWeight: 500,
+            color: 'var(--ryokan-subtle, #8B7D6B)',
+            letterSpacing: 5,
+          }}
+        >
+          LOCATION
+        </span>
+        <span
+          className="block"
+          style={{
+            width: 40,
+            height: 1,
+            backgroundColor: 'var(--ryokan-light-gold, #D4C5A0)',
+          }}
+        />
+      </div>
 
       {/* Ryokan name */}
       <h2
         className="text-center"
         style={{
           fontFamily: 'var(--font-heading)',
-          fontSize: 32,
+          fontSize: 'var(--r-access-addr-title-size)',
           fontWeight: 600,
           color: 'var(--ryokan-dark, #2C2418)',
-          letterSpacing: 6,
+          letterSpacing: 'var(--r-access-addr-title-ls)',
         }}
       >
         月瀬庵
@@ -33,13 +59,13 @@ export function AddressSection() {
         style={{ gap: 16 }}
       >
         <p
-          className="text-center"
+          className="r-access-addr-line1 text-center"
           style={{
             fontFamily: 'var(--font-body)',
-            fontSize: 15,
+            fontSize: 'var(--r-access-addr-line1-size)',
             fontWeight: 300,
             color: 'var(--ryokan-secondary, #6B5D4F)',
-            letterSpacing: 1.5,
+            letterSpacing: 'var(--r-access-addr-line1-ls)',
             lineHeight: 2.0,
           }}
         >
@@ -49,14 +75,27 @@ export function AddressSection() {
           className="text-center"
           style={{
             fontFamily: 'var(--font-body)',
-            fontSize: 15,
+            fontSize: 14,
             fontWeight: 300,
-            color: 'var(--ryokan-secondary, #6B5D4F)',
-            letterSpacing: 1.5,
+            color: 'var(--ryokan-subtle, #8B7D6B)',
+            letterSpacing: 1,
             lineHeight: 2.0,
           }}
         >
-          TEL: 0460-83-XXXX
+          TEL  0460-83-XXXX ｜ FAX  0460-83-XXXX
+        </p>
+        <p
+          className="text-center"
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 14,
+            fontWeight: 300,
+            color: 'var(--ryokan-subtle, #8B7D6B)',
+            letterSpacing: 1,
+            lineHeight: 2.0,
+          }}
+        >
+          チェックイン 15:00 ｜ チェックアウト 11:00
         </p>
       </div>
 

--- a/src/components/access/ContactLinkSection.tsx
+++ b/src/components/access/ContactLinkSection.tsx
@@ -6,7 +6,7 @@ export function ContactLinkSection() {
       className="flex w-full items-center justify-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '40px 80px',
+        padding: 'var(--r-access-contact-py) var(--r-access-contact-px)',
       }}
     >
       <Link
@@ -21,7 +21,7 @@ export function ContactLinkSection() {
           textAlign: 'center',
         }}
       >
-        お問い合わせ &rarr;
+        お問い合わせ →
       </Link>
     </section>
   )

--- a/src/components/access/MapSection.tsx
+++ b/src/components/access/MapSection.tsx
@@ -1,24 +1,44 @@
 export function MapSection() {
   return (
     <section
-      className="flex w-full flex-col items-center justify-center"
+      className="r-access-map flex w-full flex-col items-center justify-center"
       style={{
-        backgroundColor: 'var(--ryokan-light-bg-alt, #F0EBE0)',
-        padding: '32px 80px',
+        backgroundColor: 'var(--ryokan-info-bg, #F0EBE0)',
+        padding: 'var(--r-access-map-py) var(--r-access-map-px)',
         minHeight: 320,
       }}
     >
-      {/* Map placeholder frame */}
+      {/* Map placeholder frame — to be replaced with Google Maps iframe */}
       <div
         data-testid="map-frame"
-        className="w-full"
+        className="relative w-full overflow-hidden"
         style={{
           height: 260,
           borderRadius: 4,
           backgroundColor: 'var(--ryokan-light-bg, #EEEBE3)',
-          overflow: 'hidden',
         }}
-      />
+      >
+        {/* Overlay text placeholder */}
+        <div
+          className="flex h-full w-full items-center justify-center"
+          style={{
+            backgroundColor: '#2C241833',
+          }}
+        >
+          <span
+            style={{
+              fontFamily: 'var(--font-body)',
+              fontSize: 16,
+              fontWeight: 'normal',
+              color: 'var(--ryokan-text-on-dark, #FAF8F3)',
+              letterSpacing: 2,
+              textAlign: 'center',
+            }}
+          >
+            Google Maps 埋め込みエリア
+          </span>
+        </div>
+      </div>
 
       {/* Google Map link */}
       <a
@@ -35,7 +55,7 @@ export function MapSection() {
           textDecoration: 'none',
         }}
       >
-        Google Mapで見る &rarr;
+        Google Mapで見る →
       </a>
     </section>
   )

--- a/src/components/access/__tests__/AccessMethodsSection.test.tsx
+++ b/src/components/access/__tests__/AccessMethodsSection.test.tsx
@@ -14,32 +14,28 @@ describe('AccessMethodsSection', () => {
     expect(screen.getByText('アクセス方法')).toBeInTheDocument()
   })
 
+  it('renders the train access method card', () => {
+    render(<AccessMethodsSection />)
+    expect(screen.getByText('電車でお越しの方')).toBeInTheDocument()
+    expect(screen.getByText(/小田急ロマンスカー/)).toBeInTheDocument()
+  })
+
   it('renders the car access method card', () => {
     render(<AccessMethodsSection />)
     expect(screen.getByText('お車でお越しの方')).toBeInTheDocument()
     expect(screen.getByText(/御殿場IC/)).toBeInTheDocument()
   })
 
-  it('renders the train access method card', () => {
+  it('renders the shuttle service card', () => {
     render(<AccessMethodsSection />)
-    expect(screen.getByText('電車でお越しの方')).toBeInTheDocument()
-    expect(
-      screen.getByText(/箱根湯本駅よりバス30分/)
-    ).toBeInTheDocument()
+    expect(screen.getByText('送迎サービス')).toBeInTheDocument()
+    expect(screen.getByText(/無料送迎/)).toBeInTheDocument()
   })
 
   it('renders the bus access method card', () => {
     render(<AccessMethodsSection />)
     expect(screen.getByText('バスでお越しの方')).toBeInTheDocument()
     expect(screen.getByText(/小田原駅/)).toBeInTheDocument()
-  })
-
-  it('renders the shuttle service card', () => {
-    render(<AccessMethodsSection />)
-    expect(screen.getByText('送迎サービス')).toBeInTheDocument()
-    expect(
-      screen.getByText(/元箱根港・箱根湯本駅より送迎あり/)
-    ).toBeInTheDocument()
   })
 
   it('renders all four access method cards', () => {

--- a/src/components/access/__tests__/AddressSection.test.tsx
+++ b/src/components/access/__tests__/AddressSection.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from '@/test/utils'
 import { AddressSection } from '../AddressSection'
 
 describe('AddressSection', () => {
-  it('renders the ADDRESS English label', () => {
+  it('renders the LOCATION English label', () => {
     render(<AddressSection />)
-    expect(screen.getByText('ADDRESS')).toBeInTheDocument()
+    expect(screen.getByText('LOCATION')).toBeInTheDocument()
   })
 
   it('renders the ryokan name as section title', () => {
@@ -23,9 +23,15 @@ describe('AddressSection', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders the phone number', () => {
+  it('renders the phone and fax number', () => {
     render(<AddressSection />)
-    expect(screen.getByText(/0460-83-XXXX/)).toBeInTheDocument()
+    expect(screen.getByText(/TEL.*0460-83-XXXX.*FAX.*0460-83-XXXX/)).toBeInTheDocument()
+  })
+
+  it('renders check-in and check-out times', () => {
+    render(<AddressSection />)
+    expect(screen.getByText(/チェックイン 15:00/)).toBeInTheDocument()
+    expect(screen.getByText(/チェックアウト 11:00/)).toBeInTheDocument()
   })
 
   it('renders the section as a semantic section element', () => {

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -137,6 +137,26 @@
   --r-nav-cta-py: 14px;
   --r-nav-cta-px: 44px;
   --r-nav-cta-size: 13px;
+
+  /* Access page — Address Section */
+  --r-access-addr-py: 80px;
+  --r-access-addr-px: 200px;
+  --r-access-addr-title-size: 32px;
+  --r-access-addr-title-ls: 6px;
+  --r-access-addr-line1-size: 16px;
+  --r-access-addr-line1-ls: 1.5px;
+
+  /* Access page — Map Section */
+  --r-access-map-py: 32px;
+  --r-access-map-px: 80px;
+
+  /* Access page — Access Methods Section */
+  --r-access-methods-py: 60px;
+  --r-access-methods-px: 80px;
+
+  /* Access page — Contact Link Section */
+  --r-access-contact-py: 40px;
+  --r-access-contact-px: 80px;
 }
 
 /* --- Tablet (768px - 1023px) --- */
@@ -225,6 +245,22 @@
     --r-nav-cta-py: 12px;
     --r-nav-cta-px: 32px;
     --r-nav-cta-size: 12px;
+
+    /* Access page — Address Section */
+    --r-access-addr-py: 60px;
+    --r-access-addr-px: 100px;
+
+    /* Access page — Map Section */
+    --r-access-map-py: 32px;
+    --r-access-map-px: 60px;
+
+    /* Access page — Access Methods Section */
+    --r-access-methods-py: 60px;
+    --r-access-methods-px: 60px;
+
+    /* Access page — Contact Link Section */
+    --r-access-contact-py: 40px;
+    --r-access-contact-px: 60px;
   }
 }
 
@@ -330,6 +366,26 @@
     --r-info-padding: 32px;
     --r-info-gap: 32px;
     --r-map-h: 180px;
+
+    /* Access page — Address Section */
+    --r-access-addr-py: 60px;
+    --r-access-addr-px: 24px;
+    --r-access-addr-title-size: 24px;
+    --r-access-addr-title-ls: 4px;
+    --r-access-addr-line1-size: 14px;
+    --r-access-addr-line1-ls: 1px;
+
+    /* Access page — Map Section */
+    --r-access-map-py: 24px;
+    --r-access-map-px: 24px;
+
+    /* Access page — Access Methods Section */
+    --r-access-methods-py: 40px;
+    --r-access-methods-px: 24px;
+
+    /* Access page — Contact Link Section */
+    --r-access-contact-py: 40px;
+    --r-access-contact-px: 24px;
   }
 }
 
@@ -475,6 +531,31 @@
 @media (max-width: 767px) {
   .r-cuisine-grid {
     grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Access Methods Grid
+   PC: 4-column row | Tablet/Mobile: 1-column stack
+   =========================================== */
+
+.r-access-methods-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+}
+
+@media (max-width: 1023px) {
+  .r-access-methods-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+}
+
+@media (max-width: 767px) {
+  .r-access-methods-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Update all 4 access page sections (AddressSection, MapSection, AccessMethodsSection, ContactLinkSection) to match .pen design specifications across PC/Tablet/Mobile viewports
- Add lucide-react icons (TrainFront, Car, Bus) for access method cards with responsive 4-column (PC) to 1-column (Tablet/Mobile) grid layout
- Add access-page-specific responsive CSS variables for padding, font sizes, and letter spacing across all 3 breakpoints
- Pass subtitle prop ("箱根・芦ノ湖畔の隠れ宿へ") to PageHero matching .pen spec

## Changes
| File | Change |
|------|--------|
| `src/app/access/page.tsx` | Add `subtitle` prop to PageHero |
| `src/components/access/AddressSection.tsx` | Label: ADDRESS→LOCATION, add FAX + check-in/out times, responsive vars |
| `src/components/access/MapSection.tsx` | Add overlay placeholder text, responsive padding vars |
| `src/components/access/AccessMethodsSection.tsx` | Complete rewrite with .pen content, lucide icons, responsive grid |
| `src/components/access/ContactLinkSection.tsx` | Responsive padding vars |
| `src/lib/css/ryokan-responsive.css` | Add `--r-access-*` vars + `.r-access-methods-grid` class |
| `src/components/access/__tests__/*.test.tsx` | Update tests to match new content |

## .pen Spec Compliance
- **PC** (1440px): 4-column card grid, padding 80px 200px (address), 80px (methods/map)
- **Tablet** (768px): Single column stack, padding 60px 100px (address), 60px (methods)
- **Mobile** (375px): Single column stack, padding 60px 24px (address), 40px 24px (methods)

## Test plan
- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes  
- [x] ESLint passes (zero warnings)
- [x] All 58 test files pass (453 tests)
- [x] Access component tests: 22 tests pass

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)