### PR TITLE
feat(#194): implement legal page to .pen specs

### DIFF
--- a/src/components/legal/LegalContentSection.tsx
+++ b/src/components/legal/LegalContentSection.tsx
@@ -10,6 +10,8 @@ const labelStyle = {
   fontSize: 14,
   fontWeight: 600,
   color: '#8B7E6A',
+  lineHeight: 1.8,
+  flexShrink: 0,
 } as const
 
 const valueStyle = {
@@ -50,10 +52,8 @@ interface LegalInfoRowProps {
 function LegalInfoRow({ label, value }: LegalInfoRowProps) {
   return (
     <>
-      <div className="flex w-full">
-        <dt className="shrink-0" style={{ ...labelStyle, width: 200 }}>
-          {label}
-        </dt>
+      <div className="r-legal-info-row">
+        <dt style={labelStyle}>{label}</dt>
         <dd style={valueStyle}>{value}</dd>
       </div>
       <Divider />
@@ -87,97 +87,105 @@ const businessInfoRows: LegalInfoRowProps[] = [
 
 export function LegalContentSection() {
   return (
-    <section
-      className="flex w-full flex-col"
-      style={{
-        backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '80px 200px',
-        gap: 48,
-      }}
-    >
-      {/* Intro text */}
-      <p
+    <>
+      <section
+        className="flex w-full flex-col"
         style={{
-          fontFamily: 'var(--font-body)',
-          fontSize: 14,
-          fontWeight: 300,
-          color: 'var(--ryokan-dark, #2C2418)',
-          lineHeight: 2.2,
+          backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
+          padding: 'var(--r-legal-py) var(--r-legal-px)',
+          gap: 'var(--r-legal-gap)',
         }}
       >
-        特定商取引法第11条に基づき、以下のとおり表記いたします。
-      </p>
+        {/* Intro text */}
+        <p
+          className="w-full"
+          style={{
+            fontFamily: 'var(--font-body)',
+            fontSize: 14,
+            fontWeight: 300,
+            color: 'var(--ryokan-dark, #2C2418)',
+            lineHeight: 2.2,
+          }}
+        >
+          特定商取引法第11条に基づき、以下のとおり表記いたします。
+        </p>
 
-      {/* 事業者情報 */}
-      <div className="flex w-full flex-col" style={{ gap: 24 }}>
-        <h3 style={sectionHeadingStyle}>事業者情報</h3>
-        <Divider />
-        <dl className="flex w-full flex-col" style={{ gap: 0 }}>
-          {businessInfoRows.map((row) => (
-            <LegalInfoRow key={row.label} label={row.label} value={row.value} />
-          ))}
-        </dl>
-      </div>
+        {/* 事業者情報 */}
+        <div className="flex w-full flex-col" style={{ gap: 24 }}>
+          <h3 style={sectionHeadingStyle}>事業者情報</h3>
+          <Divider />
+          <dl className="flex w-full flex-col" style={{ gap: 24 }}>
+            {businessInfoRows.map((row) => (
+              <LegalInfoRow
+                key={row.label}
+                label={row.label}
+                value={row.value}
+              />
+            ))}
+          </dl>
+        </div>
 
-      {/* 販売価格 */}
-      <LegalTextSection
-        title="販売価格"
-        body="各宿泊プランページに表示された金額（税込）"
-      />
+        {/* 販売価格 */}
+        <LegalTextSection
+          title="販売価格"
+          body="各宿泊プランページに表示された金額（税込）"
+        />
 
-      {/* 販売価格以外の必要料金 */}
-      <LegalTextSection
-        title="販売価格以外の必要料金"
-        body="入湯税（大人150円）、消費税"
-      />
+        {/* 販売価格以外の必要料金 */}
+        <LegalTextSection
+          title="販売価格以外の必要料金"
+          body="入湯税（大人150円）、消費税"
+        />
 
-      {/* 支払方法 */}
-      <LegalTextSection
-        title="支払方法"
-        body={
-          'クレジットカード（VISA, Mastercard, JCB, AMEX）\n銀行振込（予約確定後にご案内）'
-        }
-      />
+        {/* 支払方法 */}
+        <LegalTextSection
+          title="支払方法"
+          body={
+            'クレジットカード（VISA, Mastercard, JCB, AMEX）\n銀行振込（予約確定後にご案内）'
+          }
+        />
 
-      {/* 支払時期 */}
-      <LegalTextSection
-        title="支払時期"
-        body={
-          'クレジットカード：チェックアウト時\n銀行振込：予約確定後7日以内'
-        }
-      />
+        {/* 支払時期 */}
+        <LegalTextSection
+          title="支払時期"
+          body={
+            'クレジットカード：チェックアウト時\n銀行振込：予約確定後7日以内'
+          }
+        />
 
-      {/* 商品の引渡時期 */}
-      <LegalTextSection
-        title="商品の引渡時期"
-        body="チェックイン日（予約時に指定した宿泊日）"
-      />
+        {/* 商品の引渡時期 */}
+        <LegalTextSection
+          title="商品の引渡時期"
+          body="チェックイン日（予約時に指定した宿泊日）"
+        />
 
-      {/* 返品・キャンセルについて */}
-      <LegalTextSection
-        title="返品・キャンセルについて"
-        body={
-          '以下のキャンセル料が発生いたします。\n\n・14日前まで：無料\n・7日前まで：宿泊料金の30%\n・3日前まで：宿泊料金の50%\n・前日：宿泊料金の80%\n・当日・無連絡：宿泊料金の100%'
-        }
-      />
+        {/* 返品・キャンセルについて */}
+        <LegalTextSection
+          title="返品・キャンセルについて"
+          body={
+            '以下のキャンセル料が発生いたします。\n\n・14日前まで：無料\n・7日前まで：宿泊料金の30%\n・3日前まで：宿泊料金の50%\n・前日：宿泊料金の80%\n・当日・無連絡：宿泊料金の100%'
+          }
+        />
 
-      {/* 特別条件 */}
-      <LegalTextSection
-        title="特別条件"
-        body={
-          '・未成年者の単独でのご予約はお受けしておりません\n・ペットの同伴はご遠慮いただいております'
-        }
-      />
+        {/* 特別条件 */}
+        <LegalTextSection
+          title="特別条件"
+          body={
+            '・未成年者の単独でのご予約はお受けしておりません\n・ペットの同伴はご遠慮いただいております'
+          }
+        />
+      </section>
 
-      {/* 最終更新日 */}
+      {/* 最終更新日 -- separate component per .pen spec */}
       <div
-        className="flex w-full items-center"
+        className="flex w-full items-center justify-center"
         style={{
-          padding: '40px 0 0 0',
+          backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
+          padding: 'var(--r-legal-updated-py) var(--r-legal-updated-px)',
         }}
       >
         <p
-          className="w-full text-center"
+          className="text-center"
           style={{
             fontFamily: 'var(--font-body)',
             fontSize: 12,
@@ -188,6 +196,6 @@ export function LegalContentSection() {
           最終更新日：2026年2月22日
         </p>
       </div>
-    </section>
+    </>
   )
 }

--- a/src/components/legal/__tests__/LegalContentSection.test.tsx
+++ b/src/components/legal/__tests__/LegalContentSection.test.tsx
@@ -83,6 +83,12 @@ describe('LegalContentSection', () => {
       expect(dtElements.length).toBeGreaterThanOrEqual(6)
       expect(ddElements.length).toBeGreaterThanOrEqual(6)
     })
+
+    it('renders info rows with responsive r-legal-info-row class', () => {
+      const { container } = render(<LegalContentSection />)
+      const infoRows = container.querySelectorAll('.r-legal-info-row')
+      expect(infoRows.length).toBe(6)
+    })
   })
 
   // --- Section: 販売価格 ---
@@ -247,6 +253,14 @@ describe('LegalContentSection', () => {
     })
   })
 
+  it('uses responsive CSS variables for section padding', () => {
+    const { container } = render(<LegalContentSection />)
+    const section = container.querySelector('section')
+    expect(section).toHaveStyle({
+      padding: 'var(--r-legal-py) var(--r-legal-px)',
+    })
+  })
+
   it('renders section headings with heading font family', () => {
     render(<LegalContentSection />)
     const heading = screen.getByText('事業者情報')
@@ -257,5 +271,14 @@ describe('LegalContentSection', () => {
     const { container } = render(<LegalContentSection />)
     const dividers = container.querySelectorAll('[data-testid="legal-divider"]')
     expect(dividers.length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('renders the last updated section as a separate element from the content section', () => {
+    const { container } = render(<LegalContentSection />)
+    const section = container.querySelector('section')
+    expect(section).toBeInTheDocument()
+    // The last updated text should not be inside the section element
+    const lastUpdated = screen.getByText(/最終更新日：2026年2月22日/)
+    expect(section!.contains(lastUpdated)).toBe(false)
   })
 })

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -157,6 +157,13 @@
   /* Access page — Contact Link Section */
   --r-access-contact-py: 40px;
   --r-access-contact-px: 80px;
+
+  /* Legal / Policy pages */
+  --r-legal-py: 80px;
+  --r-legal-px: 200px;
+  --r-legal-gap: 48px;
+  --r-legal-updated-py: 40px;
+  --r-legal-updated-px: 200px;
 }
 
 /* --- Tablet (768px - 1023px) --- */
@@ -261,6 +268,12 @@
     /* Access page — Contact Link Section */
     --r-access-contact-py: 40px;
     --r-access-contact-px: 60px;
+
+    /* Legal / Policy pages */
+    --r-legal-py: 80px;
+    --r-legal-px: 120px;
+    --r-legal-updated-py: 40px;
+    --r-legal-updated-px: 120px;
   }
 }
 
@@ -386,6 +399,12 @@
     /* Access page — Contact Link Section */
     --r-access-contact-py: 40px;
     --r-access-contact-px: 24px;
+
+    /* Legal / Policy pages */
+    --r-legal-py: 60px;
+    --r-legal-px: 24px;
+    --r-legal-updated-py: 24px;
+    --r-legal-updated-px: 24px;
   }
 }
 
@@ -556,6 +575,24 @@
   .r-access-methods-grid {
     grid-template-columns: 1fr;
     gap: 24px;
+  }
+}
+
+/* ===========================================
+   Legal Info Row: row (PC/Tablet) -> column (Mobile)
+   =========================================== */
+
+.r-legal-info-row {
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .r-legal-info-row {
+    flex-direction: column;
+    gap: 4px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add responsive CSS variables (`--r-legal-py/px`, `--r-legal-updated-py/px`, `--r-legal-gap`) for legal/policy page padding across PC (200px), Tablet (120px), and Mobile (24px)
- Add `.r-legal-info-row` responsive layout class: horizontal with `gap: 24px` on PC/Tablet, vertical stack with `gap: 4px` on Mobile (matching .pen Mobile Legal Content spec)
- Separate "Last Updated" into its own block with independent responsive padding, matching the .pen component structure (`PC/Tablet/Mobile Legal Last Updated`)
- Update business info row styles: add `lineHeight: 1.8`, `flexShrink: 0` to labels; set `dl` gap to `24px` per .pen spec

## Test plan
- [x] All 40 legal page tests pass (8 page + 32 component)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes with zero warnings
- [x] New test: responsive `r-legal-info-row` class presence on all 6 info rows
- [x] New test: last updated section is rendered outside the `<section>` element
- [x] New test: section uses responsive CSS variable for padding

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)