### PR TITLE
chore(#226): add Claude preflight and recovery runbook

### DIFF
--- a/docs/CLAUDE_RECOVERY_RUNBOOK.md
+++ b/docs/CLAUDE_RECOVERY_RUNBOOK.md
@@ -1,0 +1,115 @@
+# Claude Local Recovery Runbook
+
+Last updated: 2026-02-26
+
+Related issue: `#226`
+
+## 1. Goal
+- Recover quickly from local Claude execution failures.
+- Keep Phase execution traceable and restartable.
+
+## 2. Normal state definition
+All items below should be true:
+- `npm run preflight:claude` passes
+- `git status --short --branch` is clean on the intended branch
+- GitHub has no stale Open PRs for completed tasks
+- `claude` starts without file descriptor errors
+
+## 3. Preflight before starting work
+Run this from repo root:
+
+```bash
+npm run preflight:claude
+```
+
+If it fails, fix the reported item first.
+
+## 4. Incident A: working directory missing
+Symptom example:
+
+```text
+Working directory \".../tsukise-an\" no longer exists
+```
+
+Recovery:
+
+```bash
+cd ~/Desktop/claude/TestPlayground/PencilTest
+
+# If repo directory exists, use clean worktree
+git -C tsukise-an fetch origin
+git -C tsukise-an worktree add tsukise-an-clean-main origin/main
+cd tsukise-an-clean-main
+
+# If repo directory does not exist, re-clone
+git clone git@github.com:k1nyA/tsukise-an.git
+cd tsukise-an
+```
+
+Then:
+
+```bash
+npm run preflight:claude
+```
+
+## 5. Incident B: low max file descriptors
+Symptom example:
+
+```text
+error: An unknown error occurred, possibly due to low max file descriptors (Unexpected)
+Current limit: 256
+```
+
+Recovery (current shell):
+
+```bash
+ulimit -n 65536
+ulimit -n
+```
+
+Persist for zsh:
+
+```bash
+echo 'ulimit -n 65536' >> ~/.zshrc
+exec zsh
+ulimit -n
+```
+
+If still blocked:
+
+```bash
+sudo launchctl limit maxfiles 65536 200000
+```
+
+Then retry:
+
+```bash
+npm run preflight:claude
+claude --dangerously-skip-permissions
+```
+
+## 6. Incident C: stale/missing worktree metadata
+Symptom:
+- preflight reports missing worktree paths
+
+Recovery:
+
+```bash
+git worktree prune
+git worktree list
+npm run preflight:claude
+```
+
+## 7. Safety checklist before destructive git ops
+Before `reset --hard`, branch cleanup, or worktree removal:
+- Save diff patch for WIP files
+- `git stash push -u -m "<message>"`
+- Confirm target repo with `gh repo view --json nameWithOwner -q .nameWithOwner`
+- Prefer explicit `-R k1nyA/tsukise-an` in `gh` write commands
+
+## 8. Handover note template
+When stopping mid-phase, record:
+- Current branch and cleanliness (`git status --short --branch`)
+- Open PR numbers and merge status
+- Next issue to start
+- Incident links (`#226`) and recovery status

--- a/docs/ENGINEERING_AUTOMATION_SETUP.md
+++ b/docs/ENGINEERING_AUTOMATION_SETUP.md
@@ -10,6 +10,8 @@
   - `npm run typecheck`
 - Verify:
   - `npm run verify`（lint + typecheck + build）
+- Claude preflight:
+  - `npm run preflight:claude`（開始前のローカル実行前チェック）
 - Husky:
   - `.husky/pre-commit` -> `lint-staged`
   - `.husky/pre-push` -> `typecheck`, `lint`
@@ -64,3 +66,12 @@
 - スキーマ定義: 入力/外部レスポンスの不整合検知
 - コンパイルチェック: 型崩れをPRで即検知
 - テストライブラリ: 回帰防止を自動化
+
+## 6. Claude 実行前チェック / 復旧導線
+- セッション開始時は `npm run preflight:claude` を実行してから作業開始する
+- 失敗時は `docs/CLAUDE_RECOVERY_RUNBOOK.md` に従って復旧する
+- 代表的な検知項目:
+  - `cwd` が存在しない
+  - `gh` の repo context 不一致
+  - `ulimit -n` 不足
+  - 失効した worktree metadata

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:run": "vitest run",
     "test:ci": "vitest run --reporter=verbose",
     "test:backend:smoke": "node scripts/backend-e2e-smoke.mjs",
+    "preflight:claude": "bash scripts/claude-preflight.sh",
     "verify": "npm run lint && npm run typecheck && npm run build",
     "add": "liftkit add",
     "check:links": "node scripts/check-internal-links.mjs",

--- a/scripts/claude-preflight.sh
+++ b/scripts/claude-preflight.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MIN_FD="${CLAUDE_MIN_FD:-65536}"
+EXPECTED_REPO="${CLAUDE_EXPECTED_REPO:-k1nyA/tsukise-an}"
+
+errors=0
+warnings=0
+
+ok() {
+  printf '[OK] %s\n' "$1"
+}
+
+warn() {
+  printf '[WARN] %s\n' "$1"
+  warnings=$((warnings + 1))
+}
+
+fail() {
+  printf '[FAIL] %s\n' "$1"
+  errors=$((errors + 1))
+}
+
+printf '== Claude Preflight ==\n'
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  ok "git worktree detected"
+else
+  fail "current directory is not inside a git worktree: $PWD"
+fi
+
+if [ -d "$PWD" ]; then
+  ok "current directory exists: $PWD"
+else
+  fail "current directory does not exist: $PWD"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  current_repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+  if [ -z "$current_repo" ]; then
+    warn "gh repo context could not be detected. Use -R for write operations."
+  elif [ "$current_repo" = "$EXPECTED_REPO" ]; then
+    ok "gh repo context is $current_repo"
+  else
+    fail "gh repo context is $current_repo (expected: $EXPECTED_REPO). Use -R."
+  fi
+else
+  warn "gh command not found"
+fi
+
+fd_limit="$(ulimit -n 2>/dev/null || echo unknown)"
+if [ "$fd_limit" = "unlimited" ]; then
+  ok "ulimit -n is unlimited"
+elif [ "$fd_limit" = "unknown" ]; then
+  warn "ulimit -n could not be read"
+elif [ "$fd_limit" -ge "$MIN_FD" ]; then
+  ok "ulimit -n is $fd_limit (>= $MIN_FD)"
+else
+  fail "ulimit -n is $fd_limit (< $MIN_FD). Run: ulimit -n $MIN_FD"
+fi
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  missing_count=0
+  while IFS= read -r wt_path; do
+    if [ ! -d "$wt_path" ]; then
+      warn "missing worktree path in metadata: $wt_path"
+      missing_count=$((missing_count + 1))
+    fi
+  done < <(git worktree list --porcelain | awk '/^worktree /{print substr($0,10)}')
+
+  if [ "$missing_count" -eq 0 ]; then
+    ok "all worktree paths exist"
+  else
+    fail "worktree metadata includes missing path(s). Run: git worktree prune"
+  fi
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  warn "working tree has uncommitted changes"
+else
+  ok "working tree is clean"
+fi
+
+if [ "$errors" -gt 0 ]; then
+  printf '\nPreflight failed: %s error(s), %s warning(s)\n' "$errors" "$warnings"
+  exit 1
+fi
+
+printf '\nPreflight passed: 0 error(s), %s warning(s)\n' "$warnings"


### PR DESCRIPTION
## Summary\n- add `npm run preflight:claude` command and preflight script\n- add local recovery runbook for missing working directory / low file descriptor incidents\n- wire preflight + runbook into engineering automation docs\n\n## Why\n- make the recent worktree disappearance + FD limit incident reproducible, trackable, and recoverable\n\nCloses #226