### PR TITLE
feat(#234): お料理ページ レスポンシブ実装

### DIFF
--- a/src/app/cuisine/page.tsx
+++ b/src/app/cuisine/page.tsx
@@ -34,11 +34,11 @@ export default function CuisinePage() {
 
         {/* Related page links */}
         <div
-          className="flex w-full items-center justify-center"
+          className="r-cuisine-links w-full"
           style={{
             backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-            gap: 60,
-            padding: '40px 80px',
+            padding:
+              'var(--r-cuisine-links-py) var(--r-cuisine-links-px)',
           }}
         >
           <Link

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 @import "../lib/css/index.css";
 @import "../lib/css/ryokan-theme.css";
 @import "../lib/css/ryokan-responsive.css";
+@import "../components/cuisine/cuisine-responsive.css";
 
 /* ============================================================
    Tailwind v4 @theme — Design Token Registration

--- a/src/components/cuisine/AllergyInfoSection.tsx
+++ b/src/components/cuisine/AllergyInfoSection.tsx
@@ -28,8 +28,8 @@ export function AllergyInfoSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-light-bg-alt, #F0EBE0)',
-        padding: '80px 120px',
-        gap: 48,
+        padding: 'var(--r-cuisine-allergy-py) var(--r-cuisine-allergy-px)',
+        gap: 'var(--r-cuisine-allergy-gap)',
       }}
     >
       {/* Title */}
@@ -37,17 +37,18 @@ export function AllergyInfoSection() {
         className="text-center"
         style={{
           fontFamily: 'var(--font-heading)',
-          fontSize: 24,
+          fontSize: 'var(--r-title-xs)',
           fontWeight: 600,
           color: 'var(--ryokan-dark, #2C2418)',
-          letterSpacing: 4,
+          letterSpacing: 'var(--r-title-spacing-sm)',
+          margin: 0,
         }}
       >
         アレルギー・特別対応
       </h2>
 
-      {/* Allergy items grid */}
-      <div className="flex w-full" style={{ gap: 40 }}>
+      {/* Allergy items: row on PC/Tablet, column on Mobile */}
+      <div className="r-cuisine-allergy-items w-full">
         {allergyItems.map((item) => (
           <div
             key={item.title}
@@ -72,6 +73,7 @@ export function AllergyInfoSection() {
                 fontWeight: 600,
                 color: 'var(--ryokan-dark, #2C2418)',
                 letterSpacing: 1,
+                margin: 0,
               }}
             >
               {item.title}
@@ -87,6 +89,7 @@ export function AllergyInfoSection() {
                 color: 'var(--ryokan-secondary, #6B5D4F)',
                 lineHeight: 1.8,
                 whiteSpace: 'pre-line',
+                margin: 0,
               }}
             >
               {item.description}

--- a/src/components/cuisine/BreakfastSection.tsx
+++ b/src/components/cuisine/BreakfastSection.tsx
@@ -1,25 +1,32 @@
+import Image from 'next/image'
+
 export function BreakfastSection() {
   return (
-    <section className="flex w-full overflow-hidden" style={{ height: 480 }}>
-      {/* Content - dark background, left side */}
+    <section className="r-textimg-layout w-full overflow-hidden">
+      {/* Content - dark background (left on PC/Tablet, bottom on Mobile via column-reverse) */}
       <div
         data-testid="breakfast-content"
-        className="flex flex-1 flex-col justify-center"
+        className="flex flex-col justify-center"
         style={{
+          flex: 1,
           backgroundColor: 'var(--ryokan-dark, #2C2418)',
-          padding: 60,
-          gap: 24,
+          padding: 'var(--r-imgtext-padding)',
+          gap: 'var(--r-imgtext-gap)',
         }}
       >
         {/* Label */}
-        <div className="flex items-center" style={{ gap: 16 }}>
+        <div
+          className="flex items-center"
+          style={{ gap: 'var(--r-imgtext-label-gap)' }}
+        >
           <span
             className="block"
             style={{
-              width: 30,
+              width: 'var(--r-imgtext-label-line-w)',
               height: 1,
               backgroundColor: 'var(--ryokan-gold, #8B6914)',
             }}
+            aria-hidden="true"
           />
           <span
             style={{
@@ -27,7 +34,7 @@ export function BreakfastSection() {
               fontSize: 12,
               fontWeight: 500,
               color: 'var(--ryokan-gold, #8B6914)',
-              letterSpacing: 5,
+              letterSpacing: 'var(--r-imgtext-label-ls)',
             }}
           >
             BREAKFAST
@@ -38,10 +45,11 @@ export function BreakfastSection() {
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
-            fontSize: 28,
+            fontSize: 'var(--r-title-sm)',
             fontWeight: 600,
             color: 'var(--ryokan-text-on-dark, #FAF8F3)',
-            letterSpacing: 4,
+            letterSpacing: 'var(--r-title-spacing-sm)',
+            margin: 0,
           }}
         >
           朝餉
@@ -51,28 +59,37 @@ export function BreakfastSection() {
         <p
           style={{
             fontFamily: 'var(--font-body)',
-            fontSize: 15,
+            fontSize: 'var(--r-body-md)',
             fontWeight: 300,
             color: 'var(--ryokan-light-gold, #D4C5A0)',
             letterSpacing: 1,
             lineHeight: 2.2,
             whiteSpace: 'pre-line',
+            margin: 0,
           }}
         >
           {`箱根の朝を迎える、心温まる朝餉。\n炊きたての土鍋ご飯、焼き魚、\n地元の豆腐や漬物を中心に、\n滋味深い和朝食をご用意いたします。\n\n朝の芦ノ湖を眺めながら、\n旅の朝を彩るひとときをお過ごしください。`}
         </p>
       </div>
 
-      {/* Image placeholder - right side */}
+      {/* Image (right on PC/Tablet, top on Mobile via column-reverse) */}
       <div
-        aria-label="朝食のイメージ"
-        className="flex-shrink-0"
+        className="relative overflow-hidden"
         style={{
-          width: 640,
-          height: 480,
-          backgroundColor: 'var(--ryokan-darkest, #1A150E)',
+          width: 'var(--r-imgtext-img-width)',
+          height: 'var(--r-imgtext-img-h)',
+          flexShrink: 0,
+          minHeight: 280,
         }}
-      />
+      >
+        <Image
+          src="/images/cuisine-breakfast-main.png"
+          alt="朝食のイメージ"
+          fill
+          className="object-cover"
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 800px"
+        />
+      </div>
     </section>
   )
 }

--- a/src/components/cuisine/ConceptSection.tsx
+++ b/src/components/cuisine/ConceptSection.tsx
@@ -4,20 +4,27 @@ export function ConceptSection() {
   return (
     <section
       className="flex w-full flex-col items-center"
-      style={{ padding: '100px 200px', gap: 48 }}
+      style={{
+        padding: 'var(--r-cuisine-concept-py) var(--r-cuisine-concept-px)',
+        gap: 'var(--r-cuisine-concept-gap)',
+        backgroundImage: 'url(/images/cuisine-concept-bg.png)',
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
     >
       {/* Label with decorative lines */}
       <SectionLabel english="PHILOSOPHY" />
 
       {/* Section title */}
       <h2
-        className="text-center"
+        className="r-cuisine-concept-body"
         style={{
           fontFamily: 'var(--font-heading)',
-          fontSize: 32,
+          fontSize: 'var(--r-cuisine-concept-title)',
           fontWeight: 600,
           color: 'var(--ryokan-dark, #2C2418)',
-          letterSpacing: 6,
+          letterSpacing: 'var(--r-cuisine-concept-title-ls)',
+          margin: 0,
         }}
       >
         土地の恵みを、一皿に。
@@ -25,15 +32,16 @@ export function ConceptSection() {
 
       {/* Body text */}
       <p
-        className="text-center"
+        className="r-cuisine-concept-body"
         style={{
           fontFamily: 'var(--font-body)',
-          fontSize: 16,
+          fontSize: 'var(--r-cuisine-concept-body)',
           fontWeight: 300,
           color: 'var(--ryokan-secondary, #6B5D4F)',
-          letterSpacing: 1.5,
-          lineHeight: 2.4,
-          maxWidth: 620,
+          letterSpacing: 'var(--r-cuisine-concept-body-ls)',
+          lineHeight: 'var(--r-cuisine-concept-body-lh)',
+          maxWidth: 'var(--r-cuisine-concept-body-max-w)',
+          margin: 0,
         }}
       >
         月瀬庵の料理長・水月が手掛ける月替わり懐石は、

--- a/src/components/cuisine/DiningRoomSection.tsx
+++ b/src/components/cuisine/DiningRoomSection.tsx
@@ -1,35 +1,50 @@
+import Image from 'next/image'
+
 export function DiningRoomSection() {
   return (
-    <section className="flex w-full overflow-hidden" style={{ height: 480 }}>
-      {/* Image placeholder - left side */}
+    <section className="r-imgtext-layout w-full overflow-hidden">
+      {/* Image (left on PC/Tablet, top on Mobile) */}
       <div
-        aria-label="食事処のイメージ"
-        className="flex-shrink-0"
+        className="relative overflow-hidden"
         style={{
-          width: 640,
-          height: 480,
-          backgroundColor: 'var(--ryokan-darkest, #1A150E)',
+          width: 'var(--r-imgtext-img-width)',
+          height: 'var(--r-imgtext-img-h)',
+          flexShrink: 0,
+          minHeight: 280,
         }}
-      />
+      >
+        <Image
+          src="/images/cuisine-ingredients-main.png"
+          alt="食事処のイメージ"
+          fill
+          className="object-cover"
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 800px"
+        />
+      </div>
 
-      {/* Content - right side */}
+      {/* Content (right on PC/Tablet, bottom on Mobile) */}
       <div
-        className="flex flex-1 flex-col justify-center"
+        className="flex flex-col justify-center"
         style={{
+          flex: 1,
           backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-          padding: 60,
-          gap: 24,
+          padding: 'var(--r-imgtext-padding)',
+          gap: 'var(--r-imgtext-gap)',
         }}
       >
         {/* Label */}
-        <div className="flex items-center" style={{ gap: 16 }}>
+        <div
+          className="flex items-center"
+          style={{ gap: 'var(--r-imgtext-label-gap)' }}
+        >
           <span
             className="block"
             style={{
-              width: 30,
+              width: 'var(--r-imgtext-label-line-w)',
               height: 1,
               backgroundColor: 'var(--ryokan-gold, #8B6914)',
             }}
+            aria-hidden="true"
           />
           <span
             style={{
@@ -37,7 +52,7 @@ export function DiningRoomSection() {
               fontSize: 12,
               fontWeight: 500,
               color: 'var(--ryokan-gold, #8B6914)',
-              letterSpacing: 5,
+              letterSpacing: 'var(--r-imgtext-label-ls)',
             }}
           >
             DINING
@@ -48,10 +63,11 @@ export function DiningRoomSection() {
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
-            fontSize: 24,
+            fontSize: 'var(--r-title-xs)',
             fontWeight: 600,
             color: 'var(--ryokan-dark, #2C2418)',
-            letterSpacing: 4,
+            letterSpacing: 'var(--r-title-spacing-sm)',
+            margin: 0,
           }}
         >
           食事処「月影」
@@ -61,12 +77,13 @@ export function DiningRoomSection() {
         <p
           style={{
             fontFamily: 'var(--font-body)',
-            fontSize: 14,
+            fontSize: 'var(--r-body-sm)',
             fontWeight: 300,
             color: 'var(--ryokan-secondary, #6B5D4F)',
             letterSpacing: 0.5,
             lineHeight: 2,
             whiteSpace: 'pre-line',
+            margin: 0,
           }}
         >
           {`お食事は、離れの食事処「月影」にてご用意いたします。\n完全個室の空間で、他のお客様を気にすることなく\nごゆっくりとお召し上がりいただけます。\n\n窓越しに望む芦ノ湖の景色とともに、\n料理長が心を込めてお届けする一皿一皿を\nどうぞお愉しみください。`}

--- a/src/components/cuisine/IngredientsSection.tsx
+++ b/src/components/cuisine/IngredientsSection.tsx
@@ -1,35 +1,50 @@
+import Image from 'next/image'
+
 export function IngredientsSection() {
   return (
-    <section className="flex w-full overflow-hidden" style={{ height: 480 }}>
-      {/* Image placeholder */}
+    <section className="r-imgtext-layout w-full overflow-hidden">
+      {/* Image (left on PC/Tablet, top on Mobile) */}
       <div
-        aria-label="食材のイメージ"
-        className="flex-shrink-0"
+        className="relative overflow-hidden"
         style={{
-          width: 640,
-          height: 480,
-          backgroundColor: 'var(--ryokan-darkest, #1A150E)',
+          width: 'var(--r-imgtext-img-width)',
+          height: 'var(--r-imgtext-img-h)',
+          flexShrink: 0,
+          minHeight: 280,
         }}
-      />
+      >
+        <Image
+          src="/images/cuisine-ingredients-main.png"
+          alt="食材のイメージ"
+          fill
+          className="object-cover"
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 450px, 800px"
+        />
+      </div>
 
       {/* Content */}
       <div
-        className="flex flex-1 flex-col justify-center"
+        className="flex flex-col justify-center"
         style={{
+          flex: 1,
           backgroundColor: 'var(--ryokan-light-bg-alt, #F0EBE0)',
-          padding: 60,
-          gap: 24,
+          padding: 'var(--r-imgtext-padding)',
+          gap: 'var(--r-imgtext-gap)',
         }}
       >
         {/* Label */}
-        <div className="flex items-center" style={{ gap: 16 }}>
+        <div
+          className="flex items-center"
+          style={{ gap: 'var(--r-imgtext-label-gap)' }}
+        >
           <span
             className="block"
             style={{
-              width: 30,
+              width: 'var(--r-imgtext-label-line-w)',
               height: 1,
               backgroundColor: 'var(--ryokan-gold, #8B6914)',
             }}
+            aria-hidden="true"
           />
           <span
             style={{
@@ -37,7 +52,7 @@ export function IngredientsSection() {
               fontSize: 12,
               fontWeight: 500,
               color: 'var(--ryokan-gold, #8B6914)',
-              letterSpacing: 5,
+              letterSpacing: 'var(--r-imgtext-label-ls)',
             }}
           >
             INGREDIENTS
@@ -48,10 +63,11 @@ export function IngredientsSection() {
         <h2
           style={{
             fontFamily: 'var(--font-heading)',
-            fontSize: 28,
+            fontSize: 'var(--r-title-sm)',
             fontWeight: 600,
             color: 'var(--ryokan-dark, #2C2418)',
-            letterSpacing: 4,
+            letterSpacing: 'var(--r-title-spacing-sm)',
+            margin: 0,
           }}
         >
           食材へのこだわり
@@ -61,12 +77,13 @@ export function IngredientsSection() {
         <p
           style={{
             fontFamily: 'var(--font-body)',
-            fontSize: 15,
+            fontSize: 'var(--r-body-md)',
             fontWeight: 300,
             color: 'var(--ryokan-secondary, #6B5D4F)',
             letterSpacing: 1,
             lineHeight: 2.2,
             whiteSpace: 'pre-line',
+            margin: 0,
           }}
         >
           {`小田原漁港から届く朝獲れの鮮魚、\n箱根の山が育む山菜や茸、\n地元農家から届く有機野菜。\n\n料理長自ら毎朝市場に足を運び、\nその日最も旬を迎えた素材だけを\n厳選して仕入れています。\n\n「この土地でしか味わえない一皿」を\nお届けすることが私たちの誇りです。`}

--- a/src/components/cuisine/KaisekiMenuSection.tsx
+++ b/src/components/cuisine/KaisekiMenuSection.tsx
@@ -1,46 +1,49 @@
+import Image from 'next/image'
+
 type MenuItem = {
   name: string
   description: string
+  image?: string
   imageLabel: string
 }
 
-const menuRow1: MenuItem[] = [
+const menuItems: MenuItem[] = [
   {
     name: '先附',
     description: '季節の先付け三種盛り\n春菊の白和え、蛍烏賊の酢味噌',
+    image: '/images/cuisine-kaiseki-sakizuke.png',
     imageLabel: '先附の写真',
   },
   {
     name: '椀物',
     description: '蛤の真薯仕立て\n木の芽の香り、柚子皮を添えて',
+    image: '/images/cuisine-kaiseki-wanmono.png',
     imageLabel: '椀物の写真',
   },
   {
     name: '造り',
     description: '小田原の地魚三種盛り\n本日の鮮魚をお造りで',
+    image: '/images/cuisine-kaiseki-tsukuri.png',
     imageLabel: '造りの写真',
   },
-]
-
-const menuRow2: MenuItem[] = [
   {
     name: '焼物',
     description: '駿河湾産金目鯛の西京焼き\n木の芽味噌を添えて',
+    image: '/images/cuisine-kaiseki-yakimono.png',
     imageLabel: '焼物の写真',
   },
   {
     name: '煮物',
     description: '飛龍頭と聖護院大根の炊き合わせ\n柚子の香りとともに',
+    image: '/images/cuisine-kaiseki-nimono.png',
     imageLabel: '煮物の写真',
   },
   {
     name: '水菓子',
     description: '季節の果実と自家製甘味\n抹茶とともに',
+    image: '/images/cuisine-kaiseki-mizugashi.png',
     imageLabel: '水菓子の写真',
   },
-]
-
-const menuRow3: MenuItem[] = [
   {
     name: '八寸',
     description: '季節の前菜を少しずつ\n盛り合わせた一皿',
@@ -60,16 +63,31 @@ const menuRow3: MenuItem[] = [
 
 function MenuCard({ item }: { item: MenuItem }) {
   return (
-    <div className="flex w-full flex-col overflow-hidden" style={{ flex: '1 1 0' }}>
-      {/* Image placeholder */}
+    <div className="flex w-full flex-col overflow-hidden">
+      {/* Image */}
       <div
-        aria-label={item.imageLabel}
-        style={{
-          width: '100%',
-          height: 260,
-          backgroundColor: 'var(--ryokan-dark, #2C2418)',
-        }}
-      />
+        className="relative w-full overflow-hidden"
+        style={{ height: 'var(--r-cuisine-kaiseki-card-img-h)' }}
+      >
+        {item.image ? (
+          <Image
+            src={item.image}
+            alt={item.imageLabel}
+            fill
+            className="object-cover"
+            sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 33vw"
+          />
+        ) : (
+          <div
+            aria-label={item.imageLabel}
+            style={{
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'var(--ryokan-dark, #2C2418)',
+            }}
+          />
+        )}
+      </div>
 
       {/* Info */}
       <div
@@ -87,6 +105,7 @@ function MenuCard({ item }: { item: MenuItem }) {
             fontWeight: 600,
             color: 'var(--ryokan-dark, #2C2418)',
             letterSpacing: 2,
+            margin: 0,
           }}
         >
           {item.name}
@@ -99,6 +118,7 @@ function MenuCard({ item }: { item: MenuItem }) {
             color: 'var(--ryokan-secondary, #6B5D4F)',
             lineHeight: 1.8,
             whiteSpace: 'pre-line',
+            margin: 0,
           }}
         >
           {item.description}
@@ -114,8 +134,9 @@ export function KaisekiMenuSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '60px 80px 100px 80px',
-        gap: 40,
+        padding:
+          'var(--r-cuisine-kaiseki-pt) var(--r-cuisine-kaiseki-px) var(--r-cuisine-kaiseki-pb) var(--r-cuisine-kaiseki-px)',
+        gap: 'var(--r-cuisine-kaiseki-gap)',
       }}
     >
       {/* Title */}
@@ -123,32 +144,19 @@ export function KaisekiMenuSection() {
         className="text-center"
         style={{
           fontFamily: 'var(--font-heading)',
-          fontSize: 24,
+          fontSize: 'var(--r-cuisine-kaiseki-title)',
           fontWeight: 600,
           color: 'var(--ryokan-dark, #2C2418)',
-          letterSpacing: 4,
+          letterSpacing: 'var(--r-cuisine-kaiseki-title-ls)',
+          margin: 0,
         }}
       >
         月替わり懐石  — 如月の膳 —
       </h2>
 
-      {/* Row 1 */}
-      <div className="flex w-full" style={{ gap: 24 }}>
-        {menuRow1.map((item) => (
-          <MenuCard key={item.name} item={item} />
-        ))}
-      </div>
-
-      {/* Row 2 */}
-      <div className="flex w-full" style={{ gap: 24 }}>
-        {menuRow2.map((item) => (
-          <MenuCard key={item.name} item={item} />
-        ))}
-      </div>
-
-      {/* Row 3 */}
-      <div className="flex w-full" style={{ gap: 24 }}>
-        {menuRow3.map((item) => (
+      {/* Responsive Grid: 3-col PC / 2-col Tablet / 1-col Mobile */}
+      <div className="r-cuisine-grid">
+        {menuItems.map((item) => (
           <MenuCard key={item.name} item={item} />
         ))}
       </div>

--- a/src/components/cuisine/__tests__/BreakfastSection.test.tsx
+++ b/src/components/cuisine/__tests__/BreakfastSection.test.tsx
@@ -20,9 +20,9 @@ describe('BreakfastSection', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders an image placeholder with aria-label', () => {
+  it('renders an image with descriptive alt text', () => {
     render(<BreakfastSection />)
-    expect(screen.getByLabelText('朝食のイメージ')).toBeInTheDocument()
+    expect(screen.getByAltText('朝食のイメージ')).toBeInTheDocument()
   })
 
   it('renders the section as a semantic section element', () => {

--- a/src/components/cuisine/__tests__/DiningRoomSection.test.tsx
+++ b/src/components/cuisine/__tests__/DiningRoomSection.test.tsx
@@ -20,9 +20,9 @@ describe('DiningRoomSection', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders an image placeholder with aria-label', () => {
+  it('renders an image with descriptive alt text', () => {
     render(<DiningRoomSection />)
-    expect(screen.getByLabelText('食事処のイメージ')).toBeInTheDocument()
+    expect(screen.getByAltText('食事処のイメージ')).toBeInTheDocument()
   })
 
   it('renders the section as a semantic section element', () => {

--- a/src/components/cuisine/__tests__/IngredientsSection.test.tsx
+++ b/src/components/cuisine/__tests__/IngredientsSection.test.tsx
@@ -20,9 +20,9 @@ describe('IngredientsSection', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders an image placeholder with aria-label', () => {
+  it('renders an image with descriptive alt text', () => {
     render(<IngredientsSection />)
-    expect(screen.getByLabelText('食材のイメージ')).toBeInTheDocument()
+    expect(screen.getByAltText('食材のイメージ')).toBeInTheDocument()
   })
 
   it('renders the section as a semantic section element', () => {

--- a/src/components/cuisine/__tests__/KaisekiMenuSection.test.tsx
+++ b/src/components/cuisine/__tests__/KaisekiMenuSection.test.tsx
@@ -41,10 +41,17 @@ describe('KaisekiMenuSection', () => {
     expect(section).toBeInTheDocument()
   })
 
-  it('renders image placeholders with descriptive aria-labels', () => {
+  it('renders images for courses with available photos', () => {
     render(<KaisekiMenuSection />)
-    expect(screen.getByLabelText('先附の写真')).toBeInTheDocument()
-    expect(screen.getByLabelText('椀物の写真')).toBeInTheDocument()
-    expect(screen.getByLabelText('造りの写真')).toBeInTheDocument()
+    expect(screen.getByAltText('先附の写真')).toBeInTheDocument()
+    expect(screen.getByAltText('椀物の写真')).toBeInTheDocument()
+    expect(screen.getByAltText('造りの写真')).toBeInTheDocument()
+  })
+
+  it('renders placeholder images for courses without photos', () => {
+    render(<KaisekiMenuSection />)
+    expect(screen.getByLabelText('八寸の写真')).toBeInTheDocument()
+    expect(screen.getByLabelText('揚物の写真')).toBeInTheDocument()
+    expect(screen.getByLabelText('食事の写真')).toBeInTheDocument()
   })
 })

--- a/src/components/cuisine/cuisine-responsive.css
+++ b/src/components/cuisine/cuisine-responsive.css
@@ -1,0 +1,128 @@
+/* ===========================================
+   Cuisine Page Responsive CSS Variables
+   Breakpoints: Mobile(<768) / Tablet(768-1023) / PC(>=1024)
+   =========================================== */
+
+/* --- PC (default, >= 1024px) --- */
+:root {
+  /* Cuisine Concept Section */
+  --r-cuisine-concept-py: 100px;
+  --r-cuisine-concept-px: 200px;
+  --r-cuisine-concept-gap: 48px;
+  --r-cuisine-concept-title: 32px;
+  --r-cuisine-concept-title-ls: 6px;
+  --r-cuisine-concept-body: 16px;
+  --r-cuisine-concept-body-ls: 1.5px;
+  --r-cuisine-concept-body-lh: 2.4;
+  --r-cuisine-concept-body-max-w: 620px;
+
+  /* Kaiseki Menu Section */
+  --r-cuisine-kaiseki-pt: 60px;
+  --r-cuisine-kaiseki-px: 80px;
+  --r-cuisine-kaiseki-pb: 100px;
+  --r-cuisine-kaiseki-gap: 40px;
+  --r-cuisine-kaiseki-title: 24px;
+  --r-cuisine-kaiseki-title-ls: 4px;
+  --r-cuisine-kaiseki-card-img-h: 260px;
+
+  /* Allergy Section */
+  --r-cuisine-allergy-py: 80px;
+  --r-cuisine-allergy-px: 120px;
+  --r-cuisine-allergy-gap: 48px;
+
+  /* Related Links Section */
+  --r-cuisine-links-py: 40px;
+  --r-cuisine-links-px: 80px;
+  --r-cuisine-links-gap: 60px;
+}
+
+/* --- Tablet (768px - 1023px) --- */
+@media (max-width: 1023px) {
+  :root {
+    --r-cuisine-concept-py: 80px;
+    --r-cuisine-concept-px: 100px;
+    --r-cuisine-concept-title: 28px;
+    --r-cuisine-concept-title-ls: 5px;
+    --r-cuisine-concept-body: 14px;
+    --r-cuisine-concept-body-ls: 1px;
+    --r-cuisine-concept-body-lh: 2.2;
+
+    --r-cuisine-kaiseki-px: 60px;
+    --r-cuisine-kaiseki-pb: 80px;
+
+    --r-cuisine-allergy-py: 60px;
+    --r-cuisine-allergy-px: 80px;
+
+    --r-cuisine-links-px: 60px;
+  }
+}
+
+/* --- Mobile (< 768px) --- */
+@media (max-width: 767px) {
+  :root {
+    --r-cuisine-concept-py: 60px;
+    --r-cuisine-concept-px: 24px;
+    --r-cuisine-concept-gap: 40px;
+    --r-cuisine-concept-title: 24px;
+    --r-cuisine-concept-title-ls: 3px;
+    --r-cuisine-concept-body: 14px;
+    --r-cuisine-concept-body-ls: 1px;
+    --r-cuisine-concept-body-lh: 2.2;
+    --r-cuisine-concept-body-max-w: 100%;
+
+    --r-cuisine-kaiseki-pt: 40px;
+    --r-cuisine-kaiseki-px: 24px;
+    --r-cuisine-kaiseki-pb: 60px;
+
+    --r-cuisine-allergy-py: 60px;
+    --r-cuisine-allergy-px: 24px;
+
+    --r-cuisine-links-py: 40px;
+    --r-cuisine-links-px: 24px;
+    --r-cuisine-links-gap: 60px;
+  }
+}
+
+/* ===========================================
+   Cuisine Page Responsive Utility Classes
+   =========================================== */
+
+/* Allergy items: row on PC/Tablet, column on Mobile */
+.r-cuisine-allergy-items {
+  display: flex;
+  flex-direction: row;
+  gap: 40px;
+}
+
+@media (max-width: 767px) {
+  .r-cuisine-allergy-items {
+    flex-direction: column;
+    gap: 32px;
+  }
+}
+
+/* Cuisine Links: row on PC/Tablet, column on Mobile */
+.r-cuisine-links {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--r-cuisine-links-gap);
+}
+
+@media (max-width: 767px) {
+  .r-cuisine-links {
+    flex-direction: column;
+  }
+}
+
+/* Concept body: center on PC/Tablet, left on Mobile */
+.r-cuisine-concept-body {
+  text-align: center;
+}
+
+@media (max-width: 767px) {
+  .r-cuisine-concept-body {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- お料理ページをPCデザインスペック準拠に修正（CSS変数化）
- Tablet (768px) / Mobile (375px) レスポンシブ対応を実装
- Closes #234

## Changes
- **ConceptSection**: レスポンシブpadding・font-size・背景画像追加
- **KaisekiMenuSection**: flex行 → CSS Grid (`r-cuisine-grid`) に変換、3col→2col→1col レスポンシブ、実画像追加
- **IngredientsSection**: ImgText レスポンシブ（`r-imgtext-layout`クラス）、実画像追加
- **BreakfastSection**: TextImg レスポンシブ（`r-textimg-layout`クラス）、実画像追加
- **DiningRoomSection**: ImgText レスポンシブ、実画像追加
- **AllergyInfoSection**: レスポンシブpadding、アイテム配置（row→column）
- **Related Links**: レスポンシブflex-direction（`r-cuisine-links`クラス）
- **cuisine-responsive.css**: お料理ページ専用CSS変数・ユーティリティクラス新規作成
- テストを `Image` コンポーネントの `alt` テキスト対応に更新

## New CSS Variables
- `--r-cuisine-concept-py/px/gap/title/title-ls/body/body-ls/body-lh/body-max-w`
- `--r-cuisine-kaiseki-pt/px/pb/gap/title/title-ls/card-img-h`
- `--r-cuisine-allergy-py/px/gap`
- `--r-cuisine-links-py/px/gap`

## Test plan
- [x] npm run lint — No errors
- [x] npm run build — Success
- [x] vitest run cuisine tests — 32/32 passed
- [ ] PC (1440px) 目視確認
- [ ] Tablet (768px) 目視確認
- [ ] Mobile (375px) 目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)