### PR TITLE
feat(#238): お問い合わせページ レスポンシブ実装

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@
 @import "../components/onsen/onsen-responsive.css";
 @import "../components/experience/experience-responsive.css";
 @import "../components/access/access-responsive.css";
+@import "../components/contact/contact-responsive.css";
 
 /* ============================================================
    Tailwind v4 @theme — Design Token Registration

--- a/src/components/ContactForm.module.css
+++ b/src/components/ContactForm.module.css
@@ -1,8 +1,8 @@
 .form {
-  padding: 30px;
-  border: 1px solid rgba(139, 105, 20, 0.22);
-  border-radius: 14px;
-  background: #fff;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
 }
 
 .row {
@@ -97,11 +97,7 @@
   cursor: not-allowed;
 }
 
-@media (max-width: 880px) {
-  .form {
-    padding: 20px;
-  }
-
+@media (max-width: 767px) {
   .row {
     grid-template-columns: 1fr;
     gap: 14px;

--- a/src/components/contact/ContactFormSection.tsx
+++ b/src/components/contact/ContactFormSection.tsx
@@ -12,15 +12,15 @@ export function ContactFormSection({ accessKey = '' }: ContactFormSectionProps) 
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-form-bg, #F0EBE0)',
-        padding: '80px 120px',
-        gap: 40,
+        padding: 'var(--r-contact-form-py) var(--r-contact-form-px)',
+        gap: 'var(--r-contact-form-gap)',
       }}
     >
       <div
         className="flex w-full flex-col"
         style={{
           backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-          padding: '60px 80px',
+          padding: 'var(--r-contact-form-inner-py) var(--r-contact-form-inner-px)',
           gap: 24,
           borderRadius: 4,
           border: '1px solid #D4C5A033',

--- a/src/components/contact/ContactInfoSection.tsx
+++ b/src/components/contact/ContactInfoSection.tsx
@@ -18,19 +18,19 @@ const infoValueStyle = {
 export function ContactInfoSection() {
   return (
     <section
-      className="flex w-full items-center justify-center"
+      className="r-contact-info-layout w-full"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '80px 120px',
-        gap: 40,
+        padding: 'var(--r-contact-info-py) var(--r-contact-info-px)',
+        gap: 'var(--r-contact-info-gap)',
       }}
     >
       {/* Phone column */}
       <div
         className="flex flex-col items-center"
-        style={{ width: 400, gap: 20 }}
+        style={{ width: 'var(--r-contact-phone-width)', gap: 20 }}
       >
-        {/* Phone icon placeholder */}
+        {/* Phone icon */}
         <svg
           aria-hidden="true"
           width="32"
@@ -84,10 +84,10 @@ export function ContactInfoSection() {
         </p>
       </div>
 
-      {/* Divider */}
+      {/* Divider - hidden on Tablet/Mobile */}
       <span
         data-testid="contact-info-divider"
-        className="block"
+        className="r-contact-info-divider"
         style={{
           width: 1,
           height: 80,
@@ -97,8 +97,8 @@ export function ContactInfoSection() {
 
       {/* Info row: FAX, Mail, LINE */}
       <div
-        className="flex justify-center"
-        style={{ gap: 60 }}
+        className="r-contact-info-items"
+        style={{ gap: 'var(--r-contact-info-items-gap)' }}
       >
         {/* FAX column */}
         <div

--- a/src/components/contact/ContactIntroSection.tsx
+++ b/src/components/contact/ContactIntroSection.tsx
@@ -6,8 +6,8 @@ export function ContactIntroSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '80px 200px',
-        gap: 40,
+        padding: 'var(--r-contact-intro-py) var(--r-contact-intro-px)',
+        gap: 'var(--r-contact-intro-gap)',
       }}
     >
       {/* Section label */}
@@ -18,10 +18,10 @@ export function ContactIntroSection() {
         className="text-center"
         style={{
           fontFamily: 'var(--font-heading)',
-          fontSize: 28,
+          fontSize: 'var(--r-contact-intro-title)',
           fontWeight: 600,
           color: 'var(--ryokan-dark, #2C2418)',
-          letterSpacing: 4,
+          letterSpacing: 'var(--r-contact-intro-title-ls)',
         }}
       >
         お気軽にご相談ください
@@ -32,12 +32,12 @@ export function ContactIntroSection() {
         className="text-center"
         style={{
           fontFamily: 'var(--font-body)',
-          fontSize: 16,
+          fontSize: 'var(--r-contact-intro-body)',
           fontWeight: 300,
           color: 'var(--ryokan-secondary, #6B5D4F)',
           letterSpacing: 1.5,
           lineHeight: 2.2,
-          maxWidth: 600,
+          maxWidth: 'var(--r-contact-intro-body-max-w)',
         }}
       >
         ご宿泊のご相談、お部屋の空き状況、

--- a/src/components/contact/contact-responsive.css
+++ b/src/components/contact/contact-responsive.css
@@ -1,0 +1,113 @@
+/* ===========================================
+   Contact Page Responsive CSS Variables
+   Breakpoints: Mobile(<768) / Tablet(768-1023) / PC(>=1024)
+   =========================================== */
+
+/* --- PC (default, >= 1024px) --- */
+:root {
+  /* Contact Intro Section */
+  --r-contact-intro-py: 80px;
+  --r-contact-intro-px: 200px;
+  --r-contact-intro-gap: 40px;
+  --r-contact-intro-title: 28px;
+  --r-contact-intro-title-ls: 4px;
+  --r-contact-intro-body: 16px;
+  --r-contact-intro-body-max-w: 600px;
+
+  /* Contact Form Section */
+  --r-contact-form-py: 80px;
+  --r-contact-form-px: 120px;
+  --r-contact-form-gap: 40px;
+  --r-contact-form-inner-py: 60px;
+  --r-contact-form-inner-px: 80px;
+
+  /* Contact Info Section */
+  --r-contact-info-py: 80px;
+  --r-contact-info-px: 120px;
+  --r-contact-info-gap: 40px;
+  --r-contact-info-items-gap: 60px;
+  --r-contact-phone-width: 400px;
+}
+
+/* --- Tablet (768px - 1023px) --- */
+@media (max-width: 1023px) {
+  :root {
+    --r-contact-intro-py: 60px;
+    --r-contact-intro-px: 100px;
+
+    --r-contact-form-py: 60px;
+    --r-contact-form-px: 80px;
+    --r-contact-form-inner-px: 60px;
+
+    --r-contact-info-py: 40px;
+    --r-contact-info-px: 60px;
+    --r-contact-info-gap: 32px;
+    --r-contact-info-items-gap: 32px;
+  }
+}
+
+/* --- Mobile (< 768px) --- */
+@media (max-width: 767px) {
+  :root {
+    --r-contact-intro-py: 60px;
+    --r-contact-intro-px: 24px;
+    --r-contact-intro-title: 22px;
+    --r-contact-intro-title-ls: 2px;
+    --r-contact-intro-body: 14px;
+    --r-contact-intro-body-max-w: 100%;
+
+    --r-contact-form-py: 60px;
+    --r-contact-form-px: 24px;
+    --r-contact-form-inner-py: 40px;
+    --r-contact-form-inner-px: 24px;
+
+    --r-contact-info-py: 60px;
+    --r-contact-info-px: 24px;
+    --r-contact-info-gap: 32px;
+    --r-contact-info-items-gap: 24px;
+    --r-contact-phone-width: 100%;
+  }
+}
+
+/* ===========================================
+   Contact Page Responsive Utility Classes
+   =========================================== */
+
+/* Contact Info layout: row on PC, column on Tablet/Mobile */
+.r-contact-info-layout {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 1023px) {
+  .r-contact-info-layout {
+    flex-direction: column;
+  }
+}
+
+/* Contact Info divider: visible on PC, hidden on Tablet/Mobile */
+.r-contact-info-divider {
+  display: block;
+}
+
+@media (max-width: 1023px) {
+  .r-contact-info-divider {
+    display: none;
+  }
+}
+
+/* Contact Info items row: row on PC, column on Tablet/Mobile */
+.r-contact-info-items {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+
+@media (max-width: 1023px) {
+  .r-contact-info-items {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- お問い合わせページをPCデザインスペック準拠に修正
- Tablet (768px) / Mobile (375px) レスポンシブ対応
- Closes #238

## Changes
- **ContactIntroSection**: パディング・フォントサイズ・タイトル字間をCSS変数で制御
- **ContactFormSection**: セクションと内部コンテナのパディングをCSS変数で制御
- **ContactInfoSection**: PC横並び→Tablet/Mobile縦積み、仕切り線の表示制御
- **ContactForm.module.css**: 重複コンテナスタイル除去、ブレイクポイント統一(767px)
- **globals.css**: merge conflict解決、contact-responsive.css import追加
- **contact-responsive.css**: 新規作成（CSS変数 + ユーティリティクラス）

## New CSS Variables
- `--r-contact-intro-py/px/gap/title/title-ls/body/body-max-w`
- `--r-contact-form-py/px/gap/inner-py/inner-px`
- `--r-contact-info-py/px/gap/items-gap`
- `--r-contact-phone-width`

## Utility Classes
- `.r-contact-info-layout` — row(PC) / column(Tablet/Mobile)
- `.r-contact-info-divider` — visible(PC) / hidden(Tablet/Mobile)
- `.r-contact-info-items` — row(PC) / column(Tablet/Mobile)

## Test plan
- [x] npm run lint — No errors
- [x] npm run build — Compiled successfully
- [x] vitest (35 tests) — All passing
- [ ] PC (1440px) 目視確認
- [ ] Tablet (768px) 目視確認
- [ ] Mobile (375px) 目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)