### PR TITLE
feat(#237): 予約ページ レスポンシブ実装

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,7 @@
 @import "../components/experience/experience-responsive.css";
 @import "../components/access/access-responsive.css";
 @import "../components/contact/contact-responsive.css";
+@import "../components/reservation/reservation-responsive.css";
 
 /* ============================================================
    Tailwind v4 @theme — Design Token Registration

--- a/src/components/reservation/BookingMethodsSection.tsx
+++ b/src/components/reservation/BookingMethodsSection.tsx
@@ -22,7 +22,7 @@ export function BookingMethodsSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '60px 120px',
+        padding: 'var(--r-resv-booking-py) var(--r-resv-booking-px)',
         gap: 32,
       }}
     >
@@ -38,12 +38,12 @@ export function BookingMethodsSection() {
         ご予約方法
       </h2>
 
-      <div className="flex w-full" style={{ gap: 24 }}>
+      <div className="r-resv-booking-grid">
         {methods.map((method) => (
           <div
             key={method.name}
             data-testid="booking-method-card"
-            className="flex flex-1 flex-col items-center"
+            className="flex flex-col items-center"
             style={{
               backgroundColor: 'var(--ryokan-light-bg, #F0EBE0)',
               borderRadius: 4,

--- a/src/components/reservation/CalendarSection.tsx
+++ b/src/components/reservation/CalendarSection.tsx
@@ -16,7 +16,7 @@ export function CalendarSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-light-bg, #F0EBE0)',
-        padding: '60px 120px',
+        padding: 'var(--r-resv-calendar-py) var(--r-resv-calendar-px)',
         gap: 32,
       }}
     >

--- a/src/components/reservation/PlanSection.tsx
+++ b/src/components/reservation/PlanSection.tsx
@@ -27,7 +27,7 @@ export function PlanSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-light-bg, #F0EBE0)',
-        padding: '80px 120px',
+        padding: 'var(--r-resv-plans-py) var(--r-resv-plans-px)',
         gap: 40,
       }}
     >
@@ -43,12 +43,12 @@ export function PlanSection() {
         宿泊プラン
       </h2>
 
-      <div className="flex w-full" style={{ gap: 24 }}>
+      <div className="r-resv-plans-grid">
         {plans.map((plan) => (
           <div
             key={plan.name}
             data-testid="plan-card"
-            className="flex flex-1 flex-col overflow-hidden"
+            className="flex flex-col overflow-hidden"
             style={{
               backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
               borderRadius: 4,
@@ -68,6 +68,7 @@ export function PlanSection() {
                 src={plan.image}
                 alt={plan.name}
                 fill
+                sizes="(max-width: 767px) 100vw, (max-width: 1023px) 33vw, 33vw"
                 style={{ objectFit: 'cover' }}
               />
             </div>

--- a/src/components/reservation/PolicySection.tsx
+++ b/src/components/reservation/PolicySection.tsx
@@ -22,7 +22,7 @@ export function PolicySection() {
       className="flex w-full flex-col"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '60px 120px',
+        padding: 'var(--r-resv-policy-py) var(--r-resv-policy-px)',
         gap: 32,
       }}
     >
@@ -38,12 +38,12 @@ export function PolicySection() {
         ご予約に関するご注意
       </h2>
 
-      <div className="flex w-full" style={{ gap: 40 }}>
+      <div className="r-resv-policy-grid">
         {policies.map((policy) => (
           <div
             key={policy.title}
             data-testid="policy-column"
-            className="flex flex-1 flex-col"
+            className="flex flex-col"
             style={{ gap: 16 }}
           >
             <h3

--- a/src/components/reservation/ReservationIntroSection.tsx
+++ b/src/components/reservation/ReservationIntroSection.tsx
@@ -12,7 +12,7 @@ export function ReservationIntroSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '80px 200px',
+        padding: 'var(--r-resv-intro-py) var(--r-resv-intro-px)',
         gap: 32,
       }}
     >
@@ -31,15 +31,13 @@ export function ReservationIntroSection() {
         ご予約の流れ
       </h2>
 
-      <div
-        className="flex w-full items-center justify-center"
-        style={{ gap: 40 }}
-      >
+      <div className="r-resv-steps">
         {steps.map((step, index) => (
           <div key={step.number} className="flex items-center" style={{ gap: 40 }}>
             {/* Arrow before step (except first) */}
             {index > 0 && (
               <span
+                className="r-resv-step-arrow"
                 data-testid="step-arrow"
                 style={{
                   fontFamily: 'var(--font-accent)',

--- a/src/components/reservation/RoomSelectionSection.tsx
+++ b/src/components/reservation/RoomSelectionSection.tsx
@@ -33,7 +33,7 @@ export function RoomSelectionSection() {
       className="flex w-full flex-col items-center"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '60px 80px 80px 80px',
+        padding: 'var(--r-resv-rooms-pt) var(--r-resv-rooms-px) var(--r-resv-rooms-pb)',
         gap: 32,
       }}
     >
@@ -49,12 +49,12 @@ export function RoomSelectionSection() {
         客室タイプを選択してください
       </h2>
 
-      <div className="flex w-full" style={{ gap: 20 }}>
+      <div className="r-resv-rooms-grid">
         {rooms.map((room) => (
           <div
             key={room.labelEn}
             data-testid="room-card"
-            className="flex flex-1 flex-col overflow-hidden"
+            className="flex flex-col overflow-hidden"
             style={{
               borderRadius: 4,
               border: '1px solid rgba(212, 197, 160, 0.13)',
@@ -69,6 +69,7 @@ export function RoomSelectionSection() {
                 src={room.image}
                 alt={room.name}
                 fill
+                sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 25vw"
                 style={{ objectFit: 'cover' }}
               />
             </div>

--- a/src/components/reservation/reservation-responsive.css
+++ b/src/components/reservation/reservation-responsive.css
@@ -1,0 +1,192 @@
+/* ===========================================
+   Reservation Page Responsive CSS Variables
+   Breakpoints: Mobile(<768) / Tablet(768-1023) / PC(>=1024)
+   =========================================== */
+
+/* --- PC (default, >= 1024px) --- */
+:root {
+  /* Booking Flow Introduction */
+  --r-resv-intro-py: 80px;
+  --r-resv-intro-px: 200px;
+
+  /* Booking Methods */
+  --r-resv-booking-py: 60px;
+  --r-resv-booking-px: 120px;
+
+  /* Room Selection */
+  --r-resv-rooms-pt: 60px;
+  --r-resv-rooms-px: 80px;
+  --r-resv-rooms-pb: 80px;
+
+  /* Stay Plans */
+  --r-resv-plans-py: 80px;
+  --r-resv-plans-px: 120px;
+
+  /* Calendar Widget */
+  --r-resv-calendar-py: 60px;
+  --r-resv-calendar-px: 120px;
+
+  /* Policy */
+  --r-resv-policy-py: 60px;
+  --r-resv-policy-px: 120px;
+}
+
+/* --- Tablet (768px - 1023px) --- */
+@media (max-width: 1023px) {
+  :root {
+    --r-resv-intro-py: 60px;
+    --r-resv-intro-px: 100px;
+
+    --r-resv-booking-py: 60px;
+    --r-resv-booking-px: 80px;
+
+    --r-resv-rooms-pt: 60px;
+    --r-resv-rooms-px: 60px;
+    --r-resv-rooms-pb: 80px;
+
+    --r-resv-plans-py: 60px;
+    --r-resv-plans-px: 80px;
+
+    --r-resv-calendar-py: 60px;
+    --r-resv-calendar-px: 80px;
+
+    --r-resv-policy-py: 60px;
+    --r-resv-policy-px: 80px;
+  }
+}
+
+/* --- Mobile (< 768px) --- */
+@media (max-width: 767px) {
+  :root {
+    --r-resv-intro-py: 40px;
+    --r-resv-intro-px: 24px;
+
+    --r-resv-booking-py: 40px;
+    --r-resv-booking-px: 24px;
+
+    --r-resv-rooms-pt: 40px;
+    --r-resv-rooms-px: 24px;
+    --r-resv-rooms-pb: 60px;
+
+    --r-resv-plans-py: 60px;
+    --r-resv-plans-px: 24px;
+
+    --r-resv-calendar-py: 60px;
+    --r-resv-calendar-px: 24px;
+
+    --r-resv-policy-py: 40px;
+    --r-resv-policy-px: 24px;
+  }
+}
+
+/* ===========================================
+   Reservation Step Flow
+   PC: horizontal row | Tablet/Mobile: vertical column
+   =========================================== */
+
+.r-resv-steps {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  gap: 40px;
+}
+
+.r-resv-step-arrow {
+  display: block;
+}
+
+@media (max-width: 1023px) {
+  .r-resv-steps {
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .r-resv-step-arrow {
+    display: none;
+  }
+}
+
+/* ===========================================
+   Booking Methods Grid
+   PC/Tablet: 3 columns | Mobile: 1 column
+   =========================================== */
+
+.r-resv-booking-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .r-resv-booking-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Room Selection Grid
+   PC: 4 columns | Tablet: 2 columns | Mobile: 1 column
+   =========================================== */
+
+.r-resv-rooms-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  width: 100%;
+}
+
+@media (max-width: 1023px) {
+  .r-resv-rooms-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .r-resv-rooms-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Plans Grid
+   PC: 3 columns | Tablet: 3 columns | Mobile: 1 column
+   =========================================== */
+
+.r-resv-plans-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .r-resv-plans-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===========================================
+   Policy Columns
+   PC/Tablet: 3 columns row | Mobile: 1 column stack
+   =========================================== */
+
+.r-resv-policy-grid {
+  display: flex;
+  flex-direction: row;
+  gap: 40px;
+  width: 100%;
+}
+
+.r-resv-policy-grid > * {
+  flex: 1;
+}
+
+@media (max-width: 767px) {
+  .r-resv-policy-grid {
+    flex-direction: column;
+    gap: 32px;
+  }
+}


### PR DESCRIPTION
## Summary
- 予約ページをPCデザインスペック準拠に修正（CSS変数によるパディング管理）
- Tablet (768px) / Mobile (375px) レスポンシブ対応
- Closes #237

## Changes
- **ReservationIntroSection**: ステップフロー図を水平(PC) → 垂直(Tablet/Mobile)に切替、矢印のPC専用表示
- **BookingMethodsSection**: 予約方法3カードグリッド (3col → 3col → 1col)
- **RoomSelectionSection**: 客室選択グリッド (4col → 2col → 1col) + Image sizes最適化
- **PlanSection**: 宿泊プランカードグリッド (3col → 3col → 1col) + Image sizes最適化
- **CalendarSection**: カレンダーウィジェット レスポンシブパディング
- **PolicySection**: ポリシーカラム (3col → 3col → 1col)
- **reservation-responsive.css**: 新規作成（全セクション用CSS変数 + グリッドユーティリティ）
- **globals.css**: reservation-responsive.css のimport追加

## New CSS Variables
| Variable | PC | Tablet | Mobile |
|----------|-----|--------|--------|
| `--r-resv-intro-py/px` | 80/200px | 60/100px | 40/24px |
| `--r-resv-booking-py/px` | 60/120px | 60/80px | 40/24px |
| `--r-resv-rooms-pt/px/pb` | 60/80/80px | 60/60/80px | 40/24/60px |
| `--r-resv-plans-py/px` | 80/120px | 60/80px | 60/24px |
| `--r-resv-calendar-py/px` | 60/120px | 60/80px | 60/24px |
| `--r-resv-policy-py/px` | 60/120px | 60/80px | 40/24px |

## Test plan
- [x] npm run lint — pass
- [x] npm run build — pass
- [x] vitest (38 tests) — pass
- [ ] PC (1440px) 目視確認
- [ ] Tablet (768px) 目視確認
- [ ] Mobile (375px) 目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)