### PR TITLE
fix(#239): subpage audit — hero images, broken paths, season images

### DIFF
--- a/src/app/access/page.tsx
+++ b/src/app/access/page.tsx
@@ -17,6 +17,7 @@ export default function AccessPage() {
           title="アクセス"
           labelEn="ACCESS"
           subtitle="箱根・芦ノ湖畔の隠れ宿へ"
+          backgroundImage="/images/access-hero.png"
         />
         <Breadcrumb
           items={[

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -14,7 +14,7 @@ export default function ContactPage() {
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="お問い合わせ" labelEn="CONTACT" />
+        <PageHero title="お問い合わせ" labelEn="CONTACT" backgroundImage="/images/onsen-hero.png" />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/app/cuisine/page.tsx
+++ b/src/app/cuisine/page.tsx
@@ -18,7 +18,7 @@ export default function CuisinePage() {
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="お料理" labelEn="CUISINE" />
+        <PageHero title="お料理" labelEn="CUISINE" backgroundImage="/images/cuisine-hero.png" />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -17,7 +17,7 @@ export default function ExperiencePage() {
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="過ごし方" labelEn="EXPERIENCE" />
+        <PageHero title="過ごし方" labelEn="EXPERIENCE" backgroundImage="/images/experience-hero.png" />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,7 @@
 @import "../lib/css/index.css";
 @import "../lib/css/ryokan-theme.css";
 @import "../lib/css/ryokan-responsive.css";
+@import "../components/rooms/rooms-responsive.css";
 @import "../components/cuisine/cuisine-responsive.css";
 @import "../components/onsen/onsen-responsive.css";
 @import "../components/experience/experience-responsive.css";

--- a/src/app/onsen/page.tsx
+++ b/src/app/onsen/page.tsx
@@ -16,7 +16,7 @@ export default function OnsenPage() {
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="温泉" labelEn="ONSEN" />
+        <PageHero title="温泉" labelEn="ONSEN" backgroundImage="/images/onsen-hero.png" />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/app/reservation/page.tsx
+++ b/src/app/reservation/page.tsx
@@ -15,7 +15,7 @@ export default function ReservationPage() {
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="ご予約" labelEn="RESERVATION" />
+        <PageHero title="ご予約" labelEn="RESERVATION" backgroundImage="/images/reservation-hero.png" />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -7,14 +7,13 @@ import { AmenitiesSection } from '@/components/rooms/AmenitiesSection'
 import { CTASection } from '@/components/shared/CTASection/CTASection'
 import { Footer } from '@/components/shared/Footer/Footer'
 import Link from 'next/link'
-import '@/components/rooms/rooms-responsive.css'
 
 export default function RoomsPage() {
   return (
     <div className="ryokan-page">
       <Header />
       <main>
-        <PageHero title="客室" labelEn="ROOMS" />
+        <PageHero title="客室" labelEn="ROOMS" backgroundImage="/images/rooms-hero.png" />
         <Breadcrumb
           items={[
             { label: 'ホーム', href: '/' },

--- a/src/components/experience/SeasonsSection.tsx
+++ b/src/components/experience/SeasonsSection.tsx
@@ -1,23 +1,29 @@
+import Image from 'next/image'
+
 const seasons = [
   {
     label: 'Spring  —  春',
     title: '湖畔の桜と山菜',
     description: '芦ノ湖畔に咲く桜を愛でながら、\n春の山菜狩り体験を。',
+    image: '/images/experience-season-spring.png',
   },
   {
     label: 'Summer  —  夏',
     title: '湖上カヌーと花火',
     description: '早朝のカヌー体験と、\n夕涼みの花火鑑賞を。',
+    image: '/images/experience-season-summer.png',
   },
   {
     label: 'Autumn  —  秋',
     title: '紅葉と月見の宴',
     description: '色づく山々のハイキングと、\n中秋の名月を愛でる宴を。',
+    image: '/images/experience-season-autumn.png',
   },
   {
     label: 'Winter  —  冬',
     title: '雪見温泉と星空',
     description: '雪に包まれた露天風呂と、\n冬の澄んだ星空観賞を。',
+    image: '/images/experience-season-winter.png',
   },
 ]
 
@@ -55,15 +61,22 @@ export function SeasonsSection() {
             data-testid="season-card"
             className="flex flex-col overflow-hidden"
           >
-            {/* Image placeholder */}
+            {/* Season image */}
             <div
               data-testid="season-image"
-              className="w-full overflow-hidden"
+              className="relative w-full overflow-hidden"
               style={{
                 height: 'var(--r-exp-seasons-card-img-h)',
-                backgroundColor: 'var(--ryokan-light-bg, #EEEBE3)',
               }}
-            />
+            >
+              <Image
+                src={season.image}
+                alt={season.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 25vw"
+              />
+            </div>
 
             {/* Info */}
             <div

--- a/src/components/reservation/PlanSection.tsx
+++ b/src/components/reservation/PlanSection.tsx
@@ -5,19 +5,19 @@ const plans = [
     name: 'スタンダードプラン',
     description: '一泊二食付きの基本プラン',
     price: '¥45,000〜',
-    image: '/images/plans/standard.jpg',
+    image: '/images/rooms-tsukimi-main.png',
   },
   {
     name: '記念日プラン',
     description: '特別な日を彩る記念日プラン',
     price: '¥65,000〜',
-    image: '/images/plans/anniversary.jpg',
+    image: '/images/cuisine-hero.png',
   },
   {
     name: '連泊プラン',
     description: '2泊以上でお得な連泊プラン',
     price: '¥40,000〜/泊',
-    image: '/images/plans/consecutive.jpg',
+    image: '/images/onsen-hero.png',
   },
 ]
 

--- a/src/components/reservation/RoomSelectionSection.tsx
+++ b/src/components/reservation/RoomSelectionSection.tsx
@@ -5,25 +5,25 @@ const rooms = [
     labelEn: 'TSUKIMI',
     name: '月見の間',
     price: '¥85,000〜 / 1泊2食付',
-    image: '/images/rooms/tsukimi.jpg',
+    image: '/images/rooms-tsukimi-main.png',
   },
   {
     labelEn: 'KACHO',
     name: '花鳥の間',
     price: '¥65,000〜 / 1泊2食付',
-    image: '/images/rooms/kacho.jpg',
+    image: '/images/rooms-kacho-main.png',
   },
   {
     labelEn: 'FUGA',
     name: '風雅の間',
     price: '¥55,000〜 / 1泊2食付',
-    image: '/images/rooms/fuga.jpg',
+    image: '/images/rooms-fuga-main.png',
   },
   {
     labelEn: 'MIKAGAMI',
     name: '水鏡の間',
     price: '¥45,000〜 / 1泊2食付',
-    image: '/images/rooms/mikagami.jpg',
+    image: '/images/rooms-mikagami-main.png',
   },
 ]
 


### PR DESCRIPTION
## Summary
サブエージェント実装後の品質監査で発見した問題を修正。

## Critical fixes
- 予約ページ `RoomSelectionSection`: 存在しない `/images/rooms/*.jpg` → 実在する `/images/rooms-*-main.png` に修正
- 予約ページ `PlanSection`: 存在しない `/images/plans/*.jpg` → 実在する画像に修正

## Major fixes
- **全7サブページ**: `PageHero` に `backgroundImage` prop を追加（hero画像ファイルは存在していたが未指定だった）
- 過ごし方ページ `SeasonsSection`: プレースホルダーdiv → `next/image` で実画像表示に変更

## Minor fixes
- `rooms-responsive.css` を `globals.css` の `@import` に統一（rooms/page.tsx の直接importを削除）

## Test plan
- [x] npm run lint
- [x] npm run build

🤖 Generated with [Claude Code](https://claude.com/claude-code)