### PR TITLE
fix: resolve missing images in experience and access pages

### DIFF
--- a/src/components/access/MapSection.tsx
+++ b/src/components/access/MapSection.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image'
+
 export function MapSection() {
   return (
     <section
@@ -15,29 +17,15 @@ export function MapSection() {
         style={{
           height: 'var(--r-access-map-frame-h)',
           borderRadius: 4,
-          backgroundColor: 'var(--ryokan-light-bg, #EEEBE3)',
         }}
       >
-        {/* Overlay text placeholder */}
-        <div
-          className="flex h-full w-full items-center justify-center"
-          style={{
-            backgroundColor: '#2C241833',
-          }}
-        >
-          <span
-            style={{
-              fontFamily: 'var(--font-body)',
-              fontSize: 16,
-              fontWeight: 'normal',
-              color: 'var(--ryokan-text-on-dark, #FAF8F3)',
-              letterSpacing: 2,
-              textAlign: 'center',
-            }}
-          >
-            Google Maps 埋め込みエリア
-          </span>
-        </div>
+        <Image
+          src="/images/access-map.png"
+          alt="月瀬庵へのアクセスマップ"
+          fill
+          className="object-cover"
+          sizes="(max-width: 767px) 100vw, (max-width: 1023px) 100vw, 100vw"
+        />
       </div>
 
       {/* Google Map link */}

--- a/src/components/experience/ActivitiesSection.tsx
+++ b/src/components/experience/ActivitiesSection.tsx
@@ -24,7 +24,7 @@ export function ActivitiesSection() {
     <section
       className="flex w-full flex-col items-center"
       style={{
-        backgroundImage: 'var(--experience-activities-bg)',
+        backgroundImage: 'url(/images/experience-activities-bg.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         padding: 'var(--r-exp-act-py) var(--r-exp-act-px)',

--- a/src/components/experience/ConceptSection.tsx
+++ b/src/components/experience/ConceptSection.tsx
@@ -5,7 +5,7 @@ export function ConceptSection() {
     <section
       className="w-full"
       style={{
-        backgroundImage: 'var(--experience-concept-bg)',
+        backgroundImage: 'url(/images/experience-concept-bg.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
       }}

--- a/src/components/experience/FacilitiesSection.tsx
+++ b/src/components/experience/FacilitiesSection.tsx
@@ -1,3 +1,5 @@
+import Image from 'next/image'
+
 const facilities = [
   {
     title: 'ラウンジ「月影」',
@@ -22,11 +24,16 @@ export function FacilitiesSection() {
       {/* Left: Image */}
       <div
         data-testid="facility-image"
-        className="r-exp-facility-img overflow-hidden"
-        style={{
-          backgroundColor: 'var(--ryokan-light-bg, #EEEBE3)',
-        }}
-      />
+        className="r-exp-facility-img relative overflow-hidden"
+      >
+        <Image
+          src="/images/experience-facilities-main.png"
+          alt="館内施設"
+          fill
+          className="object-cover"
+          sizes="(max-width: 767px) 100vw, 640px"
+        />
+      </div>
 
       {/* Right: Content */}
       <div

--- a/src/components/experience/SeasonsSection.tsx
+++ b/src/components/experience/SeasonsSection.tsx
@@ -32,7 +32,7 @@ export function SeasonsSection() {
     <section
       className="flex w-full flex-col items-center"
       style={{
-        backgroundImage: 'var(--experience-seasons-bg)',
+        backgroundImage: 'url(/images/experience-seasons-bg.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
         padding: 'var(--r-exp-seasons-pt) var(--r-exp-seasons-px) var(--r-exp-seasons-pb)',

--- a/src/components/experience/TimelineSection.tsx
+++ b/src/components/experience/TimelineSection.tsx
@@ -185,7 +185,7 @@ export function TimelineSection() {
     <section
       className="w-full flex flex-col"
       style={{
-        backgroundImage: 'var(--experience-timeline-bg)',
+        backgroundImage: 'url(/images/experience-timeline-bg.png)',
         backgroundSize: 'cover',
         backgroundPosition: 'center',
       }}


### PR DESCRIPTION
## Summary
- Replace 4 undefined CSS variable references (`var(--experience-*-bg)`) with direct `url(/images/...)` paths in ConceptSection, ActivitiesSection, SeasonsSection, and TimelineSection
- Replace placeholder div in FacilitiesSection with Next.js `Image` component pointing to `/images/experience-facilities-main.png`
- Replace placeholder text in MapSection with Next.js `Image` component pointing to `/images/access-map.png`

## Test plan
- [x] `npm run build` passes successfully
- [x] ESLint and TypeScript typecheck pass (pre-push hooks)
- [ ] Visual verification: experience page backgrounds render correctly
- [ ] Visual verification: facilities image displays in experience page
- [ ] Visual verification: map image displays in access page

🤖 Generated with [Claude Code](https://claude.com/claude-code)