### PR TITLE
feat: harden reusable skill workflow with contract checks and guards

### DIFF
--- a/.claude/hooks/guard-design-contract.sh
+++ b/.claude/hooks/guard-design-contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Guard: Enforce design contract checks before PR create/merge.
+# PreToolUse hook for Bash commands.
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(
+  printf '%s' "$INPUT" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+
+print(payload.get("tool_input", {}).get("command", ""))
+' 2>/dev/null || echo ""
+)"
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# Run only for gh pr create/merge (including chained shell commands).
+if ! printf '%s' "$COMMAND" | grep -qE '(^|[;&|()[:space:]])gh[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$)'; then
+  exit 0
+fi
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHECK_SCRIPT="$PROJECT_ROOT/scripts/check-design-contract.mjs"
+
+if [[ ! -f "$CHECK_SCRIPT" ]]; then
+  echo "BLOCKED: design contract checker is missing." >&2
+  echo "  Expected file: $CHECK_SCRIPT" >&2
+  echo "  Command: $COMMAND" >&2
+  exit 2
+fi
+
+if ! CHECK_OUTPUT="$(cd "$PROJECT_ROOT" && node "$CHECK_SCRIPT" 2>&1)"; then
+  echo "BLOCKED: design contract check failed." >&2
+  echo "  Command: $COMMAND" >&2
+  echo "  Fix issues and re-run: node scripts/check-design-contract.mjs" >&2
+  if [[ -n "$CHECK_OUTPUT" ]]; then
+    printf '%s\n' "$CHECK_OUTPUT" >&2
+  fi
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/guard-worktree-health.sh
+++ b/.claude/hooks/guard-worktree-health.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Guard: Block high-risk commands when worktree metadata is unhealthy.
+# PreToolUse hook for Bash commands.
+set -euo pipefail
+
+INPUT="$(cat)"
+COMMAND="$(
+  printf '%s' "$INPUT" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+
+print(payload.get("tool_input", {}).get("command", ""))
+' 2>/dev/null || echo ""
+)"
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+is_high_risk=false
+if printf '%s' "$COMMAND" | grep -qE '(^|[;&|()[:space:]])gh[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$)'; then
+  is_high_risk=true
+fi
+if printf '%s' "$COMMAND" | grep -qE '(^|[;&|()[:space:]])git[[:space:]]+push([[:space:]]|$)'; then
+  is_high_risk=true
+fi
+if printf '%s' "$COMMAND" | grep -qE '(^|[;&|()[:space:]])git[[:space:]]+(merge|rebase|cherry-pick)([[:space:]]|$)'; then
+  is_high_risk=true
+fi
+if printf '%s' "$COMMAND" | grep -qE '(^|[;&|()[:space:]])git[[:space:]]+reset[[:space:]]+--hard([[:space:]]|$)'; then
+  is_high_risk=true
+fi
+if printf '%s' "$COMMAND" | grep -qE '(^|[;&|()[:space:]])git[[:space:]]+clean([[:space:]]|$)'; then
+  is_high_risk=true
+fi
+
+if [[ "$is_high_risk" != true ]]; then
+  exit 0
+fi
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKTREES_DIR="$PROJECT_ROOT/.claude/worktrees"
+
+# Detect recursive/nested checked-out repos under .claude/worktrees.
+nested_worktrees=""
+if [[ -d "$WORKTREES_DIR" ]]; then
+  nested_worktrees="$(
+    find "$WORKTREES_DIR" -mindepth 3 -type d -path '*/.claude/worktrees' -print -quit 2>/dev/null || true
+  )"
+fi
+
+if [[ -n "$nested_worktrees" ]]; then
+  echo "BLOCKED: nested .claude/worktrees detected." >&2
+  echo "  Nested path: $nested_worktrees" >&2
+  echo "  Command: $COMMAND" >&2
+  echo "  Resolve recursive worktrees before running high-risk commands." >&2
+  exit 2
+fi
+
+if ! WORKTREE_LIST="$(git -C "$PROJECT_ROOT" worktree list --porcelain 2>/dev/null)"; then
+  echo "BLOCKED: could not read 'git worktree list'." >&2
+  echo "  Command: $COMMAND" >&2
+  echo "  Verify repository health, then retry." >&2
+  exit 2
+fi
+
+declare -a missing_paths=()
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      path="${line#worktree }"
+      if [[ ! -d "$path" ]]; then
+        missing_paths+=("$path")
+      fi
+      ;;
+  esac
+done <<<"$WORKTREE_LIST"
+
+if [[ "${#missing_paths[@]}" -gt 0 ]]; then
+  echo "BLOCKED: git worktree list contains missing paths." >&2
+  echo "  Command: $COMMAND" >&2
+  for missing in "${missing_paths[@]}"; do
+    echo "  Missing: $missing" >&2
+  done
+  echo "  Run 'git worktree prune' (and cleanup) before high-risk commands." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/skills/design-audit/SKILL.md
+++ b/.claude/skills/design-audit/SKILL.md
@@ -8,9 +8,47 @@ user-invocable: true
 
 # デザイン品質監査スキル
 
-**状態: 未実装 — 次の制作実践を通じて構築予定**
+## 目的
 
-## 予定チェック項目
+.pen を SSOT（Single Source of Truth）として、横軸（崩壊/クリップ）と縦軸（一貫性）を短時間で監査し、次工程に渡せる修正案を確定する。
+
+## 共通ゲート（DRAFT/FREEZE/RELEASE）
+
+- `DRAFT`: 問題検出と修正案作成。必要なら .pen を最小修正。
+- `FREEZE`: 監査結果を固定し、`tasks/lessons.md` との整合を確認。
+- `RELEASE`: 次フェーズへ渡せる監査レポート（問題0件 or 残課題明示）を確定。
+
+## 実行前チェック（必須）
+
+1. Worktree health:
+   - `npm run preflight:claude`
+2. Design contract:
+   - `npm run check:design-contract`
+
+どちらかが失敗した場合は監査開始前に解消する。
+
+## 監査手順（再利用テンプレ）
+
+1. 対象確定  
+引数のノード ID（または `all`）を監査対象にする。
+
+2. 横軸監査（崩壊/クリップ）
+- `snapshot_layout(problemsOnly: true)` で崩壊・クリップ・はみ出しを検出
+- `batch_get` でテキスト幅崩壊（`width: 1` かつ高身長）候補を確認
+
+3. 縦軸監査（一貫性）
+- `batch_get` で text/frame を取得し、同役割の `fontSize/padding/gap/color` を比較
+- `tasks/lessons.md`（特に Lesson 1,2,8,9,10）と照合
+
+4. 修正と再監査
+- 明確な不具合は `batch_design` で最小修正
+- 再度 2-3 を回して差分を閉じる
+
+5. FREEZE 判定
+- `npm run check:design-contract` を再実行
+- lessons への追記が必要な新知見のみ `tasks/lessons.md` に反映（既存ルールの言い換えは追記しない）
+
+## チェック観点（固定）
 
 tasks/lessons.md から自動適用:
 
@@ -20,9 +58,18 @@ tasks/lessons.md から自動適用:
 4. **Lesson 9**: fill_container 崩壊（親フレームの width 未設定）がないか
 5. **Lesson 10**: コンポーネント保管フレームのデバイス幅が正しいか
 
-## 検出方法（予定）
+## 出力フォーマット（最小）
 
-- `snapshot_layout` で全ノードの計算サイズを取得
-- テキストノードで `width: 1, height > 15` を検出（Lesson 9）
-- `batch_get` で reusable コンポーネントの textGrowth/width 設定を検証
-- タイポグラフィ一貫性チェック: 同レベルの見出しで fontSize が異なるものを検出
+```md
+## design-audit 結果
+- Scope: [node/all]
+- Gate: DRAFT|FREEZE|RELEASE
+- Blocking issues: N
+- Fixed now: N
+- Carry-over: N
+
+### Findings
+| Rule | Node | Status | Action |
+|---|---|---|---|
+| Lesson 9 | abc123 | FAIL | parent width を補完 |
+```

--- a/.claude/skills/frontend-flow/SKILL.md
+++ b/.claude/skills/frontend-flow/SKILL.md
@@ -10,190 +10,82 @@ user-invocable: true
 
 ## 目的
 
-**ゼロから完成まで**を一貫したパイプラインで実行する。公式 frontend-design スキル（創造）と独自サブスキル群（精度）を組み合わせ、「美しく、かつ正確な」フロントエンドを実現。
+ゼロから完成までを、`.pen` SSOT と lessons 連携を維持しながら、DRAFT/FREEZE/RELEASE の3ゲートで安全に進める。
 
-**このスキル自体が ToDo リスト**: 未実装のサブスキル = やること。実践を通じてスノーボール式に完成させる。
+## 運用原則
+
+1. `.pen` が設計の唯一ソース（SSOT）
+2. 実装判断は `tasks/lessons.md` の既存ルールを優先
+3. 各 Phase は Gate を通過しない限り次へ進まない
+4. 生成物は次 Phase で再利用する（監査表/差分表/検証表）
+
+## 共通チェック（全 Phase 共通）
+
+開始時と FREEZE 前に以下を必須実行:
+
+1. Worktree health
+   - `npm run preflight:claude`
+2. Design contract
+   - `npm run check:design-contract`
+
+いずれか失敗時は Phase を進めず修復を優先する。
+
+## ゲート定義（DRAFT/FREEZE/RELEASE）
+
+- `DRAFT`: 調査・作成・比較を行い、候補を揃える状態
+- `FREEZE`: 変更範囲を固定し、契約チェック通過済みの状態
+- `RELEASE`: 次工程へ引き渡せる成果物が確定した状態
 
 ## フルパイプライン
 
 ```
-Phase 0: /creative-design ── ゼロからUI創造 ──── Gate: 美しいHTML/CSSが完成
+Phase 0: /creative-design ── ゼロからUI創造 ──── Gate: DRAFT
        ↓
-Phase 0.5: /code-to-pen ─── HTML→.pen変換 ──── Gate: .penに3幅デザイン完成
+Phase 0.5: /code-to-pen ─── HTML→.pen変換 ──── Gate: FREEZE
        ↓
-Phase 1: /design-audit ──── 品質・堅牢性チェック ── Gate: 問題0件
+Phase 1: /design-audit ──── 品質・堅牢性チェック ── Gate: FREEZE
        ↓
-Phase 2: /responsive-diff ── 3幅差分+CSS戦略 ── Gate: 戦略確定
+Phase 2: /responsive-diff ── 3幅差分+CSS戦略 ── Gate: FREEZE
        ↓
-Phase 3: /responsive-test ── Playwright定量検証 ── Gate: 計測値一致
+Phase 3: /responsive-test ── Playwright定量検証 ── Gate: FREEZE
        ↓
-Phase 4: /pen-to-code ────── 最終コード生成 ──── Gate: ブラウザ=デザイン
+Phase 4: /pen-to-code ────── 最終コード生成 ──── Gate: RELEASE
        ↓
 [実装完了 — 手戻りゼロ]
 ```
 
-**エントリーポイントは柔軟**: 既にデザインがある場合は Phase 1 から、CSSだけ検証したい場合は Phase 3 から開始可能。
+既にデザインがある場合は Phase 1 から開始可能。
 
----
+## 最短実行手順（再利用重視）
 
-## Phase 0: クリエイティブデザイン（公式スキル活用）
+1. DRAFT 開始  
+`/creative-design` または既存 .pen から開始し、`/code-to-pen` で 3幅を揃える。
 
-**担当**: 公式 `frontend-design` スキル（Anthropic提供）
+2. 品質固定（FREEZE-1）  
+`/design-audit` で Lesson 1/2/8/9/10 を検証し、問題を閉じる。
 
-```
-Skill: frontend-design [要件の説明]
-```
+3. 戦略固定（FREEZE-2）  
+`/responsive-diff` で差分表と CSS 戦略を1セット化する。
 
-**役割**: ゼロから美しいHTML/CSS/JSを創造する。
-- 独自性のあるタイポグラフィ・色・モーション
-- 「AI臭くない」デザイン
-- プロダクショングレードの実装
+4. 定量検証（FREEZE-3）  
+`/responsive-test` で 3幅計測値を取り、許容差内を確認する。
 
-**Gate**: ユーザーが「この方向性でいい」と承認。
+5. 実装確定（RELEASE）  
+`/pen-to-code` へ渡し、最終実装後に `npm run check:design-contract` を再実行して完了。
 
-**出力**: HTML/CSS/JS ファイル（デザインの方向性を確立するプロトタイプ）
+## Phase ごとの引き継ぎ物
 
----
+- Phase 1 → 2: 監査表（Fail/Fix/Carry-over）
+- Phase 2 → 3: 差分表 + CSS 戦略
+- Phase 3 → 4: 実測比較表 + 採用判定
 
-## Phase 0.5: HTML → .pen 変換
+## ユーザー承認ポイント
 
-**担当**: `/code-to-pen` サブスキル
+1. DRAFT 完了時（方向性）
+2. FREEZE-2 完了時（CSS 戦略）
+3. RELEASE 前（最終差分）
 
-```
-Read .claude/skills/code-to-pen/SKILL.md
-```
+## ナレッジ連携
 
-**役割**: Phase 0 で作ったHTML/CSSを .pen デザインファイルに変換し、3幅（PC/Tablet/Mobile）に展開。
-- HTML の構造を .pen のフレーム構造にマッピング
-- CSS の値を .pen のプロパティに変換
-- PC デザインを基準に Tablet/Mobile を派生
-- コンポーネント化（reusable: true）の適用
-
-**Gate**: 3幅のデザインが .pen 上で美しく表示される。
-
-**出力**: .pen ファイル内に PC/Tablet/Mobile の全セクション + コンポーネント
-
----
-
-## Phase 1: デザイン品質監査
-
-**担当**: `/design-audit` サブスキル
-
-```
-Read .claude/skills/design-audit/SKILL.md
-```
-
-**チェック項目** (tasks/lessons.md の知見を自動適用):
-- [ ] テキストノード: `textGrowth: "fixed-width"` + `width: "fill_container"` (Lesson 1)
-- [ ] 固定 height + 可変コンテンツの不整合 (Lesson 2)
-- [ ] fill_container 崩壊（親フレームの width 未設定）(Lesson 9)
-- [ ] 横並びフレームの width 必須 (Lesson 9)
-- [ ] タイポグラフィ階層の一貫性 (Lesson 8)
-- [ ] コンポーネント保管フレームのデバイス幅 (Lesson 10)
-
-**Gate**: 問題 0 件。問題があれば .pen を修正してから次へ。
-
----
-
-## Phase 2: レスポンシブ差分分析
-
-**担当**: `/responsive-diff` サブスキル
-
-```
-Read .claude/skills/responsive-diff/SKILL.md
-```
-
-**出力**:
-- 3幅プロパティ差分表（layout, fontSize, padding, gap, colors）
-- CSS 戦略マップ（flex-wrap / clamp() / breakpoint の組み合わせ）
-- コンポーネント統合提案（例: 6→2）
-- clamp() 係数の自動計算結果
-
-**Gate**: ユーザーが CSS 戦略を承認。
-
----
-
-## Phase 3: レスポンシブ統合テスト
-
-**担当**: `/responsive-test` サブスキル **[実装済み]**
-
-```
-Skill: responsive-test [PC_ID] [Tablet_ID] [Mobile_ID]
-```
-
-**出力**:
-- テスト HTML（flex-wrap + clamp() で単一コンポーネント化）
-- 3幅スクリーンショット（Playwright）
-- computed style 比較表（実測値 vs 設計値）
-- 統合判定（可能 / 微調整で可能 / 不可）
-
-**Gate**: 計測値が許容範囲内:
-| 項目 | 許容範囲 |
-|------|---------|
-| Typography | ±1px |
-| Padding/Gap | ±5px |
-| 画像比率 | ±10% |
-| Layout切替 | 完全一致必須 |
-
----
-
-## Phase 4: 最終コード生成
-
-**担当**: `/pen-to-code` サブスキル
-
-```
-Read .claude/skills/pen-to-code/SKILL.md
-```
-
-**入力**: Phase 2-3 の結果（CSS戦略 + 検証済み clamp() 値）
-**出力**: React/Next.js コンポーネント + CSS（Tailwind or CSS Modules）
-
-**Gate**: ブラウザ表示が .pen デザインと一致（Playwright で最終検証）。
-
----
-
-## フロー制御ルール
-
-1. **各 Phase の Gate を通過しないと次へ進まない**
-2. **Phase 間でコンテキストを引き継ぐ**: 差分表、CSS戦略、検証結果
-3. **問題発見時は前の Phase に戻る**（.pen修正 → Phase 1 からやり直し）
-4. **ユーザー承認ポイント**: Phase 0（方向性）、Phase 2（CSS戦略）、Phase 3（統合判定）
-
-## 並列実行パターン
-
-複数セクションを並列で制作する場合:
-1. Phase 0-2 はページ単位で実行（全セクションまとめて）
-2. Phase 3-4 はセクション単位で並列化可能（Task tool でサブエージェント起動）
-3. 各サブエージェントにサブスキルの SKILL.md パスとセクション情報を渡す
-
-```
-Task(subagent_type: "general-purpose", prompt: "
-  Read .claude/skills/responsive-test/SKILL.md の手順に従って、
-  以下のコンポーネントの検証を実行:
-  PC: x8Dpr, Tablet: 8mxcj, Mobile: sb64h
-  .pen ファイル: design/月瀬庵デザイン.pen
-")
-```
-
----
-
-## サブスキル一覧 & 進捗
-
-| Phase | スキル | パス | 状態 |
-|-------|-------|------|------|
-| 0 | /creative-design | 公式 `frontend-design` | **外部スキル（利用可能）** |
-| 0.5 | /code-to-pen | `.claude/skills/code-to-pen/SKILL.md` | **未作成** |
-| 1 | /design-audit | `.claude/skills/design-audit/SKILL.md` | プレースホルダー |
-| 2 | /responsive-diff | `.claude/skills/responsive-diff/SKILL.md` | プレースホルダー |
-| 3 | /responsive-test | `.claude/skills/responsive-test/SKILL.md` | **実装済み** |
-| 4 | /pen-to-code | `.claude/skills/pen-to-code/SKILL.md` | プレースホルダー |
-
-**残り作業**: Phase 0.5, 1, 2, 4 のスキルを実践を通じて肉付け。
-
----
-
-## ナレッジベース
-
-- `tasks/lessons.md`: 全 Lesson の蓄積（Lesson 1-12）
-- 各サブスキルは lessons.md を参照して品質基準を適用する
-- 新しい発見は即座に lessons.md に追記 → 全スキルに自動反映
+- 参照元: `tasks/lessons.md`
+- 追記条件: 新しい失敗パターン・再発防止ルールが確認できたときのみ

--- a/.claude/skills/responsive-diff/SKILL.md
+++ b/.claude/skills/responsive-diff/SKILL.md
@@ -8,25 +8,60 @@ user-invocable: true
 
 # レスポンシブ差分分析スキル
 
-**状態: 未実装 — 次の制作実践を通じて構築予定**
+## 目的
 
-## 予定機能
+.pen SSOT の PC/Tablet/Mobile 差分を、実装で再利用しやすい「1つの差分表 + 1つのCSS戦略」に圧縮する。
 
-1. **3幅差分表の自動生成**
-   - batch_get で PC/Tablet/Mobile コンポーネントを読み取り
-   - layout, width, height, fontSize, padding, gap, color の差分表を出力
+## 共通ゲート（DRAFT/FREEZE/RELEASE）
 
-2. **CSS 戦略の自動選択** (Lesson 11-12 ベース)
-   - 横↔縦切替 → flex-wrap
-   - 線形スケーリング → clamp() 1区間
-   - 非線形スケーリング → clamp() 2区間 + breakpoint
-   - 不連続切替 → media query
+- `DRAFT`: 差分抽出と戦略案を作る。
+- `FREEZE`: 戦略を固定し、契約チェックを通す。
+- `RELEASE`: 実装担当がそのまま使える差分表/CSS方針を確定。
 
-3. **clamp() 係数の自動計算**
-   - 2点 (viewport, target) から slope/intercept を算出
-   - CSS コードスニペットを生成
+## 実行前チェック（必須）
 
-4. **統合可能コンポーネントの特定**
-   - 同一構造で「横↔縦」の切替のみ → flex-wrap 統合候補
-   - タイポグラフィのみ異なる → clamp() で吸収可能
-   - 構造が異なる → 統合不可
+1. Worktree health:
+   - `npm run preflight:claude`
+2. Design contract:
+   - `npm run check:design-contract`
+
+## 分析手順（再利用テンプレ）
+
+1. 3幅取得  
+`batch_get` で PC/Tablet/Mobile の同一コンポーネントを取得（`readDepth` は必要最小）。
+
+2. 差分表を1枚に正規化  
+`layout / width / height / fontSize / padding / gap / color` のみ比較対象にする。
+
+3. 戦略分類（Lesson 11-12）
+- 横↔縦切替: `flex-wrap`
+- 線形変化: `clamp()` 1区間
+- 非線形変化: `clamp()` 2区間 + breakpoint
+- 不連続変化: media query
+
+4. clamp 係数を算出  
+2点 `(viewport, value)` から slope/intercept を算出し、CSS スニペット化。
+
+5. FREEZE 判定  
+`npm run check:design-contract` を再実行し、差分表と戦略を固定。
+
+## 統合可否ルール（固定）
+
+- 同一構造 + レイアウト切替のみ: 統合可（優先）
+- 構造同一 + 値差分中心: 統合可（clamp吸収）
+- 構造差分が大きい: 統合不可（幅別分離）
+
+## 出力フォーマット（最小）
+
+```md
+## responsive-diff 結果
+- Scope: [component/page]
+- Gate: DRAFT|FREEZE|RELEASE
+- Unified: yes/no
+
+### Diff table
+| Property | PC | Tablet | Mobile | Strategy |
+|---|---|---|---|---|
+| Title fontSize | 38 | 26 | 24 | clamp() x2 |
+| Layout | row | row | column | flex-wrap |
+```

--- a/docs/design-data/README.md
+++ b/docs/design-data/README.md
@@ -7,6 +7,7 @@
 ```
 docs/design-data/
 ├── README.md                  # このファイル
+├── project-profile.json       # デザイン契約（必須セクション/hero/related links）
 ├── design-tokens.json         # カラー・タイポグラフィ・スペーシング
 ├── top.json                   # トップページ (/)
 ├── rooms.json                 # 客室ページ (/rooms)
@@ -84,3 +85,8 @@ docs/design-data/
 - `hasImageFill: true` のノードは画像背景を持つ。実際の画像は Pencil エディタで確認
 - スタイル値は `.pen` ファイルのピクセル値。レスポンシブ実装時は比率変換が必要
 - `design-tokens.json` の CSS変数名は SPECIFICATION.md Section 8.1 と対応
+
+## Contract Check
+
+- 実行コマンド: `npm run check:design-contract`
+- チェック対象: `project-profile.json` を基準に、ページごとの必須セクション・hero title/subtitle・related links

--- a/docs/design-data/project-profile.json
+++ b/docs/design-data/project-profile.json
@@ -1,0 +1,185 @@
+{
+  "version": 1,
+  "designDataDir": "docs/design-data",
+  "pages": {
+    "rooms": {
+      "file": "rooms.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["type:header", "header"] },
+        { "id": "breadcrumb", "matchAny": ["type:breadcrumb", "breadcrumb"] },
+        { "id": "hero", "matchAny": ["type:hero", "hero"] },
+        { "id": "concept", "matchAny": ["type:concept", "concept"] },
+        { "id": "rooms_grid", "matchAny": ["type:rooms_grid", "room cards grid"] },
+        { "id": "vacancy_cta", "matchAny": ["type:vacancy_cta", "vacancy"] },
+        { "id": "amenities", "matchAny": ["type:amenities", "amenities"] },
+        { "id": "facilities", "matchAny": ["type:facilities", "facilities"] },
+        { "id": "related_links", "matchAny": ["type:related_links", "related pages"] },
+        { "id": "cta", "matchAny": ["type:cta_banner", "cta banner"] },
+        { "id": "footer", "matchAny": ["type:footer", "footer"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["type:hero", "hero"],
+        "title": null,
+        "subtitle": null
+      },
+      "relatedLinks": {
+        "required": true,
+        "sectionMatchAny": ["type:related_links", "related pages"],
+        "routes": []
+      }
+    },
+    "onsen": {
+      "file": "onsen.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["header with logo and navigation", "name:h3"] },
+        { "id": "breadcrumb", "matchAny": ["breadcrumb navigation", "name:bc2"] },
+        { "id": "hero", "matchAny": ["name:hero2", "hero section"] },
+        { "id": "concept", "matchAny": ["name:onsen concept", "concept section"] },
+        { "id": "daiyokujo", "matchAny": ["name:pcdaiyokujoref", "daiyokujo"] },
+        { "id": "rotenburo", "matchAny": ["name:pcrotenburoref", "rotenburo"] },
+        { "id": "water_quality", "matchAny": ["name:pcwaterqualityref", "water quality"] },
+        { "id": "onsen_guide", "matchAny": ["name:pconsenguideref", "onsen guide"] },
+        { "id": "bath_etiquette", "matchAny": ["name:pcbathetiref", "bath etiquette"] },
+        { "id": "navigation_links", "matchAny": ["name:pconsenlinksref", "navigation links section"] },
+        { "id": "cta", "matchAny": ["name:c3", "cta section"] },
+        { "id": "footer", "matchAny": ["name:f3", "footer"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["name:hero2", "hero section"],
+        "title": null,
+        "subtitle": null
+      },
+      "relatedLinks": {
+        "required": true,
+        "sectionMatchAny": ["name:pconsenlinksref", "navigation links section"],
+        "routes": ["/reservation", "/rooms"]
+      }
+    },
+    "cuisine": {
+      "file": "cuisine.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["header navigation", "name:h4"] },
+        { "id": "breadcrumb", "matchAny": ["breadcrumb navigation", "name:bc3"] },
+        { "id": "hero", "matchAny": ["name:hero3", "hero section"] },
+        { "id": "concept", "matchAny": ["name:cuisine concept", "concept section"] },
+        { "id": "kaiseki", "matchAny": ["name:pckref", "kaiseki menu"] },
+        { "id": "ingredients", "matchAny": ["name:newingred", "ingredients section"] },
+        { "id": "breakfast", "matchAny": ["name:breaksec4", "breakfast section"] },
+        { "id": "dining_room", "matchAny": ["name:diningsec4", "dining room section"] },
+        { "id": "allergy_info", "matchAny": ["name:pcaref", "allergy"] },
+        { "id": "cuisine_links", "matchAny": ["name:pclref", "cuisine links section"] },
+        { "id": "cta", "matchAny": ["name:c4", "cta section"] },
+        { "id": "footer", "matchAny": ["name:f4", "footer"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["name:hero3", "hero section"],
+        "title": null,
+        "subtitle": null
+      },
+      "relatedLinks": {
+        "required": true,
+        "sectionMatchAny": ["name:pclref", "cuisine links section"],
+        "routes": []
+      }
+    },
+    "experience": {
+      "file": "experience.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["label:header", "name:h5"] },
+        { "id": "breadcrumb", "matchAny": ["label:breadcrumb", "name:bc5"] },
+        { "id": "hero", "matchAny": ["label:hero section", "name:hero4"] },
+        { "id": "concept", "matchAny": ["label:concept section", "name:experience concept"] },
+        { "id": "timeline", "matchAny": ["label:timeline section", "name:timelinesec"] },
+        { "id": "seasons", "matchAny": ["label:seasons section", "name:seasonssec"] },
+        { "id": "facilities", "matchAny": ["name:pcfacref", "facilities"] },
+        { "id": "activities", "matchAny": ["name:pcactref", "activities"] },
+        { "id": "experience_links", "matchAny": ["label:experience links", "name:experiencelinkswrap"] },
+        { "id": "cta", "matchAny": ["label:cta section", "name:c5"] },
+        { "id": "footer", "matchAny": ["label:footer", "name:f5"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["label:hero section", "name:hero4"],
+        "title": null,
+        "subtitle": null
+      },
+      "relatedLinks": {
+        "required": true,
+        "sectionMatchAny": ["label:experience links", "name:experiencelinkswrap"],
+        "routes": ["/rooms", "/onsen"]
+      }
+    },
+    "access": {
+      "file": "access.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["name:h6 (header)", "header"] },
+        { "id": "breadcrumb", "matchAny": ["name:bc6 (breadcrumb)", "breadcrumb"] },
+        { "id": "hero", "matchAny": ["name:hero5 (hero section)", "hero section"] },
+        { "id": "address", "matchAny": ["name:pcaddrref", "address section"] },
+        { "id": "map", "matchAny": ["name:pcmapref", "map section"] },
+        { "id": "access_methods", "matchAny": ["name:pcaccessref", "access methods"] },
+        { "id": "contact_cta", "matchAny": ["name:pccontactref", "contact cta"] },
+        { "id": "cta", "matchAny": ["name:c6 (cta section)", "cta section"] },
+        { "id": "footer", "matchAny": ["name:f6 (footer)", "footer"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["name:hero5 (hero section)", "hero section"],
+        "title": "アクセス",
+        "subtitle": "箱根・芦ノ湖畔の隠れ宿へ"
+      },
+      "relatedLinks": {
+        "required": true,
+        "sectionMatchAny": ["name:pccontactref", "contact cta"],
+        "routes": []
+      }
+    },
+    "reservation": {
+      "file": "reservation.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["name:h7 (header)", "header"] },
+        { "id": "breadcrumb", "matchAny": ["name:bc7 (breadcrumb)", "breadcrumb"] },
+        { "id": "hero", "matchAny": ["name:hero6 (hero section)", "hero section"] },
+        { "id": "booking_flow", "matchAny": ["name:pcref1", "booking flow introduction"] },
+        { "id": "booking_methods", "matchAny": ["name:pcref2", "booking methods"] },
+        { "id": "room_selection", "matchAny": ["name:pcref3", "room type selection"] },
+        { "id": "stay_plans", "matchAny": ["name:pcref4", "stay plans"] },
+        { "id": "calendar", "matchAny": ["name:pcref5", "calendar widget"] },
+        { "id": "reservation_policy", "matchAny": ["name:pcref6", "reservation policy"] },
+        { "id": "cta", "matchAny": ["name:c7 (cta section)", "cta section"] },
+        { "id": "footer", "matchAny": ["name:f7 (footer)", "footer"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["name:hero6 (hero section)", "hero section"],
+        "title": "ご予約",
+        "subtitle": "月瀬庵でのご滞在を、お待ちしております"
+      },
+      "relatedLinks": {
+        "required": false,
+        "sectionMatchAny": ["related", "links"],
+        "routes": []
+      }
+    },
+    "contact": {
+      "file": "contact.json",
+      "requiredSections": [
+        { "id": "header", "matchAny": ["name:h8 (header)", "header"] },
+        { "id": "breadcrumb", "matchAny": ["name:bc8 (breadcrumb)", "breadcrumb"] },
+        { "id": "hero", "matchAny": ["name:hero7 (hero section)", "hero section"] },
+        { "id": "introduction", "matchAny": ["name:pcintroref", "introduction section"] },
+        { "id": "contact_form", "matchAny": ["name:pcformref", "contact form"] },
+        { "id": "phone_info", "matchAny": ["name:pcotherref", "phone & info section"] },
+        { "id": "cta", "matchAny": ["name:c8 (cta section)", "cta section"] },
+        { "id": "footer", "matchAny": ["name:f8 (footer)", "footer"] }
+      ],
+      "hero": {
+        "sectionMatchAny": ["name:hero7 (hero section)", "hero section"],
+        "title": null,
+        "subtitle": null
+      },
+      "relatedLinks": {
+        "required": false,
+        "sectionMatchAny": ["related", "links"],
+        "routes": []
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "verify": "npm run lint && npm run typecheck && npm run build",
     "add": "liftkit add",
     "check:links": "node scripts/check-internal-links.mjs",
+    "check:design-contract": "node scripts/check-design-contract.mjs",
     "gh:issue:safe": "node skills/gh-safe-authoring/scripts/gh_issue_safe.mjs",
     "gh:pr:safe": "node skills/gh-safe-authoring/scripts/gh_pr_safe.mjs",
     "prepare": "husky"

--- a/scripts/check-design-contract.mjs
+++ b/scripts/check-design-contract.mjs
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const profilePath = path.join(repoRoot, "docs/design-data/project-profile.json");
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(`Failed to read JSON: ${filePath}\n${error.message}`);
+  }
+}
+
+function normalizeText(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function normalizeNullableText(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const text = String(value).trim();
+  return text === "" ? null : text;
+}
+
+function getPrimarySections(pageData) {
+  const viewports = pageData?.viewports;
+  if (!viewports || typeof viewports !== "object") {
+    return null;
+  }
+
+  if (Array.isArray(viewports.pc?.sections)) {
+    return viewports.pc.sections;
+  }
+
+  for (const viewport of Object.values(viewports)) {
+    if (Array.isArray(viewport?.sections)) {
+      return viewport.sections;
+    }
+  }
+
+  return null;
+}
+
+function sectionSignature(section) {
+  return normalizeText(
+    [
+      `id:${section?.id ?? ""}`,
+      `name:${section?.name ?? ""}`,
+      `type:${section?.type ?? ""}`,
+      `label:${section?.label ?? ""}`,
+      `description:${section?.description ?? ""}`,
+      `content:${section?.content ?? ""}`,
+    ].join(" | "),
+  );
+}
+
+function sectionMatches(section, matchAny = []) {
+  const signature = sectionSignature(section);
+  return matchAny.some((needle) => signature.includes(normalizeText(needle)));
+}
+
+function findMatchingSections(sections, matchAny = []) {
+  if (!Array.isArray(sections) || matchAny.length === 0) {
+    return [];
+  }
+  return sections.filter((section) => sectionMatches(section, matchAny));
+}
+
+function extractHeroTitleSubtitle(heroSection) {
+  let title = null;
+  let subtitle = null;
+
+  const parseTitleSubtitlePair = (text) => {
+    const match = text.match(/title\s*:\s*([^,]+?)\s*,\s*subtitle\s*:\s*(.+)$/i);
+    if (!match) {
+      return;
+    }
+
+    if (title === null) {
+      title = normalizeNullableText(match[1]);
+    }
+    if (subtitle === null) {
+      subtitle = normalizeNullableText(match[2]);
+    }
+  };
+
+  const walk = (value) => {
+    if (value === null || value === undefined) {
+      return;
+    }
+
+    if (typeof value === "string") {
+      parseTitleSubtitlePair(value);
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item);
+      }
+      return;
+    }
+
+    if (typeof value === "object") {
+      const nodeName = normalizeText(value.name ?? "");
+      const nodeContent = normalizeNullableText(value.content);
+
+      if (nodeContent !== null) {
+        if (title === null && nodeName.includes("herotitle")) {
+          title = nodeContent;
+        }
+        if (
+          subtitle === null &&
+          (nodeName.includes("herosub") || nodeName.includes("herosubtitle"))
+        ) {
+          subtitle = nodeContent;
+        }
+      }
+
+      if (typeof value.title === "string") {
+        title = title ?? normalizeNullableText(value.title);
+      }
+      if (typeof value.subtitle === "string") {
+        subtitle = subtitle ?? normalizeNullableText(value.subtitle);
+      }
+
+      for (const childValue of Object.values(value)) {
+        walk(childValue);
+      }
+    }
+  };
+
+  walk(heroSection);
+
+  return {
+    title: normalizeNullableText(title),
+    subtitle: normalizeNullableText(subtitle),
+  };
+}
+
+function normalizeRoute(route) {
+  if (typeof route !== "string") {
+    return null;
+  }
+
+  const raw = route.trim();
+  if (!raw) {
+    return null;
+  }
+
+  let pathname = raw;
+
+  if (raw.startsWith("http://") || raw.startsWith("https://")) {
+    try {
+      pathname = new URL(raw).pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  pathname = pathname.split("#")[0].split("?")[0];
+
+  if (!pathname.startsWith("/")) {
+    return null;
+  }
+
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    pathname = pathname.slice(0, -1);
+  }
+
+  return pathname;
+}
+
+function collectRoutes(value, parentKey = "", routes = new Set()) {
+  if (value === null || value === undefined) {
+    return routes;
+  }
+
+  if (typeof value === "string") {
+    if (parentKey === "href") {
+      const normalized = normalizeRoute(value);
+      if (normalized) {
+        routes.add(normalized);
+      }
+    }
+
+    if (parentKey === "context") {
+      const hrefMatch = value.match(/href\s*:\s*([^\s,)]+)/i);
+      if (hrefMatch) {
+        const normalized = normalizeRoute(hrefMatch[1]);
+        if (normalized) {
+          routes.add(normalized);
+        }
+      }
+    }
+
+    return routes;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectRoutes(item, parentKey, routes);
+    }
+    return routes;
+  }
+
+  if (typeof value === "object") {
+    for (const [key, childValue] of Object.entries(value)) {
+      collectRoutes(childValue, key, routes);
+    }
+  }
+
+  return routes;
+}
+
+function formatSection(section) {
+  return [section?.id ?? "(no-id)", section?.name ?? "(no-name)", section?.type ?? "(no-type)"]
+    .map((part) => String(part).trim())
+    .join(" | ");
+}
+
+const profile = readJson(profilePath);
+const designDataDir = profile.designDataDir || "docs/design-data";
+const pageEntries = Object.entries(profile.pages || {});
+const failures = [];
+
+for (const [pageKey, pageContract] of pageEntries) {
+  const fileName = pageContract.file;
+  const pageFilePath = path.join(repoRoot, designDataDir, fileName);
+  const pageData = readJson(pageFilePath);
+  const sections = getPrimarySections(pageData);
+
+  const pageFailure = {
+    page: pageKey,
+    file: fileName,
+    issues: [],
+  };
+
+  if (!Array.isArray(sections)) {
+    pageFailure.issues.push({
+      type: "invalid_structure",
+      message: "Could not find viewport sections (expected viewports.pc.sections).",
+    });
+    failures.push(pageFailure);
+    continue;
+  }
+
+  const missingSections = [];
+  for (const requiredSection of pageContract.requiredSections || []) {
+    const matches = findMatchingSections(sections, requiredSection.matchAny || []);
+    if (matches.length === 0) {
+      missingSections.push(requiredSection);
+    }
+  }
+
+  if (missingSections.length > 0) {
+    pageFailure.issues.push({
+      type: "missing_sections",
+      missingSections,
+      actualSections: sections.map(formatSection),
+    });
+  }
+
+  if (pageContract.hero) {
+    const heroSections = findMatchingSections(sections, pageContract.hero.sectionMatchAny || ["hero"]);
+    const heroSection = heroSections[0] || null;
+    const actualHero = heroSection
+      ? extractHeroTitleSubtitle(heroSection)
+      : { title: null, subtitle: null };
+
+    const expectedTitle = normalizeNullableText(pageContract.hero.title);
+    const expectedSubtitle = normalizeNullableText(pageContract.hero.subtitle);
+
+    const titleMismatch = expectedTitle !== actualHero.title;
+    const subtitleMismatch = expectedSubtitle !== actualHero.subtitle;
+
+    if (heroSection === null) {
+      pageFailure.issues.push({
+        type: "hero_section_missing",
+        sectionMatchAny: pageContract.hero.sectionMatchAny || ["hero"],
+      });
+    } else if (titleMismatch || subtitleMismatch) {
+      pageFailure.issues.push({
+        type: "hero_mismatch",
+        expected: {
+          title: expectedTitle,
+          subtitle: expectedSubtitle,
+        },
+        actual: actualHero,
+      });
+    }
+  }
+
+  if (pageContract.relatedLinks) {
+    const relatedSections = findMatchingSections(
+      sections,
+      pageContract.relatedLinks.sectionMatchAny || ["related", "links"],
+    );
+
+    if (pageContract.relatedLinks.required && relatedSections.length === 0) {
+      pageFailure.issues.push({
+        type: "related_section_missing",
+        sectionMatchAny: pageContract.relatedLinks.sectionMatchAny || ["related", "links"],
+      });
+    }
+
+    const actualRoutes = Array.from(
+      relatedSections.reduce((set, section) => collectRoutes(section, "", set), new Set()),
+    ).sort();
+    const expectedRoutes = Array.from(
+      new Set((pageContract.relatedLinks.routes || []).map(normalizeRoute).filter(Boolean)),
+    ).sort();
+
+    const missingRoutes = expectedRoutes.filter((route) => !actualRoutes.includes(route));
+    const extraRoutes = actualRoutes.filter((route) => !expectedRoutes.includes(route));
+
+    if (missingRoutes.length > 0 || extraRoutes.length > 0) {
+      pageFailure.issues.push({
+        type: "related_routes_mismatch",
+        expectedRoutes,
+        actualRoutes,
+        missingRoutes,
+        extraRoutes,
+      });
+    }
+  }
+
+  if (pageFailure.issues.length > 0) {
+    failures.push(pageFailure);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Design contract check failed.");
+
+  for (const failure of failures) {
+    console.error(`\n[${failure.page}] (${failure.file})`);
+
+    for (const issue of failure.issues) {
+      if (issue.type === "invalid_structure") {
+        console.error(`- Invalid structure: ${issue.message}`);
+      }
+
+      if (issue.type === "missing_sections") {
+        console.error("- Required sections mismatch");
+        console.error("  Missing:");
+        for (const section of issue.missingSections) {
+          console.error(`  - ${section.id} (matchAny: ${section.matchAny.join(" | ")})`);
+        }
+        console.error("  Actual sections:");
+        for (const actualSection of issue.actualSections) {
+          console.error(`  - ${actualSection}`);
+        }
+      }
+
+      if (issue.type === "hero_section_missing") {
+        console.error(
+          `- Hero section missing (matchAny: ${issue.sectionMatchAny.join(" | ")})`,
+        );
+      }
+
+      if (issue.type === "hero_mismatch") {
+        console.error("- Hero title/subtitle mismatch");
+        console.error(`  title    expected: ${JSON.stringify(issue.expected.title)}`);
+        console.error(`  title    actual:   ${JSON.stringify(issue.actual.title)}`);
+        console.error(`  subtitle expected: ${JSON.stringify(issue.expected.subtitle)}`);
+        console.error(`  subtitle actual:   ${JSON.stringify(issue.actual.subtitle)}`);
+      }
+
+      if (issue.type === "related_section_missing") {
+        console.error(
+          `- Related links section missing (matchAny: ${issue.sectionMatchAny.join(" | ")})`,
+        );
+      }
+
+      if (issue.type === "related_routes_mismatch") {
+        console.error("- Related link routes mismatch");
+        console.error(`  expected routes: ${issue.expectedRoutes.join(", ") || "(none)"}`);
+        console.error(`  actual routes:   ${issue.actualRoutes.join(", ") || "(none)"}`);
+        if (issue.missingRoutes.length > 0) {
+          console.error(`  missing routes:  ${issue.missingRoutes.join(", ")}`);
+        }
+        if (issue.extraRoutes.length > 0) {
+          console.error(`  extra routes:    ${issue.extraRoutes.join(", ")}`);
+        }
+      }
+    }
+  }
+
+  process.exit(1);
+}
+
+console.log(`OK: design contract matched for ${pageEntries.length} page(s).`);


### PR DESCRIPTION
## Summary
- add a reusable design contract profile (`docs/design-data/project-profile.json`)
- add `scripts/check-design-contract.mjs` and expose `npm run check:design-contract`
- add pre-tool hook guards for worktree health and design contract gate
- upgrade skill docs (`design-audit`, `responsive-diff`, `frontend-flow`) to enforce DRAFT/FREEZE/RELEASE and preflight checks
- document contract-check usage in design-data README

## Why
This hardens the skill pipeline so the same guardrails can be reused across projects and reduces late-stage audit drift.

## Validation
- `npm run check:design-contract`
- `npm run preflight:claude`
- `npm run lint`
- `npm run typecheck`

## Related
- #251
- #252
- #253
- #254
- #255
