### PR TITLE
test: stabilize Jest invocation and document runner policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ To get started visit this url [here](https://liftkit.pages.dev/) and copy any co
 
 To learn more about how to use liftkit please visit our docs [here](https://locrian-challenge-f8e.notion.site/)
 
+## Testing Policy
+
+- Default runner: `Vitest` (`npm test`, `npm run test:run`)
+- Optional Jest lane: `npm run test:jest`
+  - Jest targets only `*.jest.test.*` files.
+  - Existing `*.test.*` and `*.spec.*` files are Vitest suites and should be run with Vitest.
+
 <!-- MARKDOWN LINKS & IMAGES -->
 
 [nextjs-shield]: https://img.shields.io/badge/Next.js-000000.svg?style=for-the-badge&logo=next.js&logoColor=white

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,14 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  // This repository uses Vitest as the default runner.
+  // Jest is kept as an explicit opt-in lane for *.jest.test.* files only.
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/?(*.)+(jest.test).[jt]s?(x)'],
+  passWithNoTests: true,
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/.next/',
+    '/.claude/worktrees/',
+    '/.claude-logs/',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:ci": "vitest run --reporter=verbose",
+    "test:jest": "npx jest --config jest.config.cjs --runInBand --passWithNoTests",
+    "test:jest:ci": "npx jest --config jest.config.cjs --ci --runInBand --passWithNoTests",
     "test:backend:smoke": "node scripts/backend-e2e-smoke.mjs",
     "preflight:claude": "bash scripts/claude-preflight.sh",
     "verify": "npm run lint && npm run typecheck && npm run build",


### PR DESCRIPTION
## Summary
- add `jest.config.cjs` so plain Jest execution does not recurse into `.claude/worktrees`
- restrict Jest discovery to `*.jest.test.*` files and allow empty runs (`passWithNoTests`)
- add explicit scripts: `test:jest`, `test:jest:ci`
- document test runner policy in README (Vitest default, Jest opt-in)

## Why
`npx jest` was failing with massive TSX/ESM parse errors and worktree false-discovery. This change makes Jest invocation deterministic and prevents accidental red builds from unrelated worktrees.

## Validation
- `npm run test:jest` ✅ (No tests found, exits 0 by design)
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run -- --reporter=dot` ⚠️ existing unrelated failure in `src/components/cuisine/__tests__/KaisekiMenuSection.test.tsx`

Closes #257
