### PR TITLE
test: align KaisekiMenuSection test with 6-item .pen SSOT

### DIFF
--- a/src/components/cuisine/__tests__/KaisekiMenuSection.test.tsx
+++ b/src/components/cuisine/__tests__/KaisekiMenuSection.test.tsx
@@ -9,7 +9,7 @@ describe('KaisekiMenuSection', () => {
     expect(screen.getByText(/如月の膳/)).toBeInTheDocument()
   })
 
-  it('renders all nine menu course names', () => {
+  it('renders all six menu course names per .pen SSOT', () => {
     render(<KaisekiMenuSection />)
     expect(screen.getByText('先附')).toBeInTheDocument()
     expect(screen.getByText('椀物')).toBeInTheDocument()
@@ -17,9 +17,6 @@ describe('KaisekiMenuSection', () => {
     expect(screen.getByText('焼物')).toBeInTheDocument()
     expect(screen.getByText('煮物')).toBeInTheDocument()
     expect(screen.getByText('水菓子')).toBeInTheDocument()
-    expect(screen.getByText('八寸')).toBeInTheDocument()
-    expect(screen.getByText('揚物')).toBeInTheDocument()
-    expect(screen.getByText('食事')).toBeInTheDocument()
   })
 
   it('renders descriptions for each course', () => {
@@ -30,9 +27,6 @@ describe('KaisekiMenuSection', () => {
     expect(screen.getByText(/駿河湾産金目鯛の西京焼き/)).toBeInTheDocument()
     expect(screen.getByText(/飛龍頭と聖護院大根/)).toBeInTheDocument()
     expect(screen.getByText(/季節の果実と自家製甘味/)).toBeInTheDocument()
-    expect(screen.getByText(/季節の前菜を少しずつ/)).toBeInTheDocument()
-    expect(screen.getByText(/旬の素材を軽やかに揚げた/)).toBeInTheDocument()
-    expect(screen.getByText(/土鍋で炊き上げる/)).toBeInTheDocument()
   })
 
   it('renders the section as a semantic section element', () => {
@@ -41,17 +35,13 @@ describe('KaisekiMenuSection', () => {
     expect(section).toBeInTheDocument()
   })
 
-  it('renders images for courses with available photos', () => {
+  it('renders images for all six courses', () => {
     render(<KaisekiMenuSection />)
     expect(screen.getByAltText('先附の写真')).toBeInTheDocument()
     expect(screen.getByAltText('椀物の写真')).toBeInTheDocument()
     expect(screen.getByAltText('造りの写真')).toBeInTheDocument()
-  })
-
-  it('renders placeholder images for courses without photos', () => {
-    render(<KaisekiMenuSection />)
-    expect(screen.getByLabelText('八寸の写真')).toBeInTheDocument()
-    expect(screen.getByLabelText('揚物の写真')).toBeInTheDocument()
-    expect(screen.getByLabelText('食事の写真')).toBeInTheDocument()
+    expect(screen.getByAltText('焼物の写真')).toBeInTheDocument()
+    expect(screen.getByAltText('煮物の写真')).toBeInTheDocument()
+    expect(screen.getByAltText('水菓子の写真')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- Update KaisekiMenuSection test from 9 menu items to 6
- PR #249 removed 3 extra items (八寸/揚物/食事) not present in .pen
- All 6 courses now have images, so placeholder test replaced with image alt text checks

## Test plan
- [x] `vitest run` — 5/5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)