### PR TITLE
fix: restore silver ratio (58.6%) for top page ImgText layout

### DIFF
--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -100,7 +100,7 @@
   --r-footer-nav-gap: 40px;
 
   /* ImgText / TextImg */
-  --r-imgtext-img-width: 800px;
+  --r-imgtext-img-width: 58.6%;
   --r-imgtext-padding: 80px;
   --r-imgtext-gap: 32px;
   --r-imgtext-img-h: auto;


### PR DESCRIPTION
## Summary
- Restore `--r-imgtext-img-width: 58.6%` (silver ratio 1:√2) on PC breakpoint
- PR #218 regressed this to `800px` (fixed pixel), breaking proportional layout

## Context
Lesson #15 documents that flex-grow ratios don't accurately produce silver ratio with large flex-basis values. The correct approach is `width: 58.6%` + `flexShrink: 0` for the image, `flex: 1` for text.

## Affected components
- `RoomSection` (top page)
- `OnsenSection` (top page)
- All ImgText/TextImg patterns using `--r-imgtext-img-width`

## Test plan
- [x] `next build` passes
- [ ] Visual check: image takes ~58.6% width on PC viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)