### PR TITLE
fix: maintain silver ratio across all viewport widths

### DIFF
--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -223,7 +223,7 @@
     --r-footer-py-bottom: 24px;
     --r-footer-nav-gap: 20px;
 
-    --r-imgtext-img-width: 450px;
+    --r-imgtext-img-width: 58.6%;
     --r-imgtext-padding: 40px 36px;
     --r-imgtext-gap: 24px;
     --r-imgtext-label-line-w: 24px;


### PR DESCRIPTION
## Summary
- Tablet breakpoint `--r-imgtext-img-width` was `450px` (fixed pixel), breaking the silver ratio (白銀比 1:√2 = 58.6%) at intermediate viewport widths
- Changed to `58.6%` so the image:text ratio slides smoothly from 1440px → 768px

## Verification (Playwright computed style)
| Viewport | Image | Text | Ratio |
|----------|-------|------|-------|
| 1440px | 844px | 596px | **58.6% : 41.4%** |
| 1024px | 600px | 424px | **58.6% : 41.4%** |
| 900px | 527px | 373px | **58.6% : 41.4%** |
| 768px | 450px | 318px | **58.6% : 41.4%** |

Follows up on #260 which fixed the PC breakpoint only.

## Test plan
- [x] Verified at 4 viewport widths via Playwright `browser_evaluate`
- [x] `npm run lint` ✅
- [x] `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)