### PR TITLE
fix: access info row horizontal on tablet per .pen

### DIFF
--- a/src/components/top/InfoSection.tsx
+++ b/src/components/top/InfoSection.tsx
@@ -169,7 +169,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
         </h2>
 
         {/* Address & Transport Info */}
-        <div className="flex flex-col w-full" style={{ gap: 24 }}>
+        <div className="r-info-access-row flex w-full" style={{ gap: 'var(--r-info-access-row-gap)' }}>
           <p
             style={{
               fontFamily: 'var(--font-body)',
@@ -192,7 +192,7 @@ export function InfoSection({ newsItems }: InfoSectionProps) {
           </p>
 
           {/* Access Methods */}
-          <div className="flex flex-col" style={{ gap: 12 }}>
+          <div className="flex flex-1 flex-col" style={{ gap: 12 }}>
             <div className="flex items-center" style={{ gap: 12 }}>
               <Car size={16} color="var(--ryokan-gold)" aria-hidden="true" />
               <span

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -129,6 +129,7 @@
   /* Info */
   --r-info-padding: 80px;
   --r-info-gap: 60px;
+  --r-info-access-row-gap: 24px;
   --r-map-h: 200px;
 
   /* Header nav */
@@ -246,6 +247,7 @@
 
     --r-info-padding: 48px;
     --r-info-gap: 40px;
+    --r-info-access-row-gap: 32px;
 
     --r-nav-gap: 24px;
     --r-nav-size: 12px;
@@ -378,6 +380,7 @@
 
     --r-info-padding: 32px;
     --r-info-gap: 32px;
+    --r-info-access-row-gap: 24px;
     --r-map-h: 180px;
 
     /* Access page — Address Section */
@@ -447,6 +450,12 @@
   flex-shrink: 0;
 }
 
+/* Info access row: address + transport side by side (PC/Tablet), column on mobile */
+.r-info-access-row {
+  flex-direction: row;
+  align-items: flex-end;
+}
+
 /* CTA buttons: row → column on mobile */
 .r-cta-btns {
   display: flex;
@@ -482,6 +491,10 @@
   }
   .r-grid-row {
     flex-direction: column;
+  }
+  .r-info-access-row {
+    flex-direction: column;
+    align-items: stretch;
   }
 }
 


### PR DESCRIPTION
## Summary
- .pen Tablet design shows address (〒250-0522...) and transport info (お車で/電車で) **side by side** (`accessInfoRow`: horizontal, gap: 32, alignItems: end)
- Code had `flex-col` (vertical stacking) — now uses `r-info-access-row` class: `row` on PC/Tablet, `column` on mobile (<=767px)

## Changes
- `InfoSection.tsx`: Address+transport container uses `r-info-access-row` class with CSS variable gap
- `ryokan-responsive.css`: New `r-info-access-row` layout class + `--r-info-access-row-gap` variable per breakpoint

## Verification
- Playwright at 768px: `flexDirection: "row"`, address (235px) left, transport (390px) right, `alignItems: flex-end`
- Screenshot confirms side-by-side layout matching .pen design
- `npm run lint` ✅ / `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)