### PR TITLE
fix: remove duplicate vacancy link and add amenity icons

### DIFF
--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -27,30 +27,6 @@ export default function RoomsPage() {
         />
         <ConceptSection />
         <RoomGridSection />
-
-        {/* Vacancy link */}
-        <div
-          className="flex w-full items-center justify-center"
-          style={{
-            backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-            padding: 'var(--r-rooms-vacancy-py) var(--r-section-px)',
-          }}
-        >
-          <Link
-            href="/reservation"
-            style={{
-              fontFamily: 'var(--font-body)',
-              fontSize: 14,
-              fontWeight: 500,
-              color: 'var(--ryokan-gold, #8B6914)',
-              letterSpacing: 1,
-              textDecoration: 'none',
-            }}
-          >
-            空室を確認する →
-          </Link>
-        </div>
-
         <AmenitiesSection />
 
         {/* Related page links */}

--- a/src/components/rooms/AmenitiesSection.tsx
+++ b/src/components/rooms/AmenitiesSection.tsx
@@ -1,22 +1,27 @@
 import Image from 'next/image'
+import { Bath, Sparkles, Moon, type LucideIcon } from 'lucide-react'
 
 type AmenityItem = {
+  icon: LucideIcon
   title: string
   description: string
 }
 
 const amenities: AmenityItem[] = [
   {
+    icon: Bath,
     title: '源泉掛け流し露天風呂',
     description:
       '全室に専用の露天風呂を完備。\n姥子温泉の源泉を\nそのままお愉しみいただけます。',
   },
   {
+    icon: Sparkles,
     title: 'こだわりの調度品',
     description:
       '地元・箱根寄木細工の家具や\n有田焼の茶器など、\n日本の伝統工芸に触れる滞在を。',
   },
   {
+    icon: Moon,
     title: '月見テラス',
     description:
       '各離れに設えた専用テラスから\n芦ノ湖に浮かぶ月を独占。\n季節の移ろいを五感で感じて。',
@@ -79,14 +84,11 @@ export function AmenitiesSection() {
               className="flex flex-col items-center"
               style={{ flex: '1 1 0', gap: 16, minWidth: 0 }}
             >
-              {/* Icon placeholder */}
-              <div
-                aria-label={amenity.title}
-                style={{
-                  width: 32,
-                  height: 32,
-                  color: 'var(--ryokan-gold, #8B6914)',
-                }}
+              {/* Icon */}
+              <amenity.icon
+                size={32}
+                color="var(--ryokan-gold, #8B6914)"
+                aria-hidden="true"
               />
 
               {/* Amenity title */}


### PR DESCRIPTION
## Summary
- Removed duplicate "空室を確認する" link from `page.tsx` (RoomGridSection already renders it; PR #250 mistakenly added a second one)
- Replaced empty `<div>` placeholders with actual lucide-react icons per .pen SSOT:
  - 源泉掛け流し露天風呂 → `Bath`
  - こだわりの調度品 → `Sparkles`
  - 月見テラス → `Moon`

## Test plan
- [x] Playwright snapshot: vacancy link appears once, icons render as `<img>` (SVG)
- [x] `npm run lint` ✅ / `npm run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)