### PR TITLE
fix: rewrite WaterQualitySection to match .pen SSOT

### DIFF
--- a/src/components/onsen/WaterQualitySection.tsx
+++ b/src/components/onsen/WaterQualitySection.tsx
@@ -1,16 +1,10 @@
 import { SectionLabel } from '@/components/shared/SectionLabel'
 
-const efficacyItems = [
-  '神経痛・筋肉痛',
-  '疲労回復',
-  '冷え性改善',
-  '美肌効果',
-] as const
-
-const qualityInfo = [
-  { label: '泉質', value: 'アルカリ性単純温泉' },
-  { label: 'pH値', value: 'pH 8.5' },
-  { label: '源泉温度', value: '62℃' },
+const qualityCards = [
+  { label: '源泉名', value: '姥子温泉\n（うばこおんせん）' },
+  { label: '泉質', value: '単純硫黄泉' },
+  { label: '泉温', value: '源泉 62.3℃\n浴槽 41〜43℃' },
+  { label: '効能', value: '神経痛・筋肉痛\n関節痛・冷え性\n美肌効果' },
 ] as const
 
 export function WaterQualitySection() {
@@ -48,75 +42,44 @@ export function WaterQualitySection() {
           泉質と効能
         </h2>
 
-        {/* Quality info grid */}
+        {/* Quality info card grid */}
         <div className="r-onsen-wq-info-grid w-full">
-          {qualityInfo.map((item) => (
-            <div key={item.label} className="flex flex-col items-center gap-3">
+          {qualityCards.map((card) => (
+            <div
+              key={card.label}
+              className="flex flex-col"
+              style={{
+                backgroundColor: '#3A3020',
+                minHeight: 168,
+                padding: '24px 32px',
+                gap: 12,
+              }}
+            >
               <span
                 style={{
                   fontFamily: 'var(--font-body)',
-                  fontSize: 'var(--r-onsen-wq-info-label-size)',
-                  fontWeight: 300,
-                  color: 'var(--ryokan-text-subtle, #C4B89A)',
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: 'var(--ryokan-gold, #8B6914)',
                   letterSpacing: 2,
                 }}
               >
-                {item.label}
+                {card.label}
               </span>
               <span
                 style={{
-                  fontFamily: 'var(--font-heading)',
-                  fontSize: 'var(--r-onsen-wq-info-val-size)',
-                  fontWeight: 600,
-                  color: 'var(--ryokan-text-on-dark, #FAF8F3)',
-                  letterSpacing: 2,
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 14,
+                  fontWeight: 300,
+                  color: 'var(--ryokan-text-subtle, #D4C5A0)',
+                  lineHeight: 1.8,
+                  whiteSpace: 'pre-line',
                 }}
               >
-                {item.value}
+                {card.value}
               </span>
             </div>
           ))}
-        </div>
-
-        {/* Divider */}
-        <span
-          className="block"
-          style={{
-            width: '100%',
-            height: 1,
-            backgroundColor: 'var(--ryokan-soft-line, #D4C5A055)',
-          }}
-        />
-
-        {/* Efficacy */}
-        <div className="flex flex-col items-center gap-4">
-          <span
-            style={{
-              fontFamily: 'var(--font-body)',
-              fontSize: 'var(--r-onsen-wq-info-label-size)',
-              fontWeight: 300,
-              color: 'var(--ryokan-text-subtle, #C4B89A)',
-              letterSpacing: 2,
-            }}
-          >
-            効能
-          </span>
-          <div className="flex flex-wrap justify-center gap-8">
-            {efficacyItems.map((item) => (
-              <span
-                key={item}
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontSize: 'var(--r-onsen-wq-efficacy-size)',
-                  fontWeight: 300,
-                  color: 'var(--ryokan-text-on-dark, #FAF8F3)',
-                  letterSpacing: 1.5,
-                }}
-              >
-                {item}
-              </span>
-            ))}
-          </div>
         </div>
       </div>
     </section>

--- a/src/components/onsen/__tests__/WaterQualitySection.test.tsx
+++ b/src/components/onsen/__tests__/WaterQualitySection.test.tsx
@@ -8,23 +8,20 @@ describe('WaterQualitySection', () => {
     expect(screen.getByText('泉質と効能')).toBeInTheDocument()
   })
 
-  it('renders the water quality type "アルカリ性単純温泉"', () => {
+  it('renders all four quality card labels per .pen SSOT', () => {
     render(<WaterQualitySection />)
-    expect(screen.getByText('アルカリ性単純温泉')).toBeInTheDocument()
+    expect(screen.getByText('源泉名')).toBeInTheDocument()
+    expect(screen.getByText('泉質')).toBeInTheDocument()
+    expect(screen.getByText('泉温')).toBeInTheDocument()
+    expect(screen.getByText('効能')).toBeInTheDocument()
   })
 
-  it('renders pH value and source temperature', () => {
+  it('renders correct values per .pen SSOT', () => {
     render(<WaterQualitySection />)
-    expect(screen.getByText(/pH 8.5/)).toBeInTheDocument()
-    expect(screen.getByText(/62℃/)).toBeInTheDocument()
-  })
-
-  it('renders efficacy items', () => {
-    render(<WaterQualitySection />)
-    expect(screen.getByText('神経痛・筋肉痛')).toBeInTheDocument()
-    expect(screen.getByText('疲労回復')).toBeInTheDocument()
-    expect(screen.getByText('冷え性改善')).toBeInTheDocument()
-    expect(screen.getByText('美肌効果')).toBeInTheDocument()
+    expect(screen.getByText(/姥子温泉/)).toBeInTheDocument()
+    expect(screen.getByText('単純硫黄泉')).toBeInTheDocument()
+    expect(screen.getByText(/源泉 62\.3℃/)).toBeInTheDocument()
+    expect(screen.getByText(/神経痛・筋肉痛/)).toBeInTheDocument()
   })
 
   it('renders within a section element', () => {

--- a/src/components/onsen/onsen-responsive.css
+++ b/src/components/onsen/onsen-responsive.css
@@ -33,9 +33,6 @@
   --r-onsen-wq-gap: 48px;
   --r-onsen-wq-title-size: 28px;
   --r-onsen-wq-title-ls: 4px;
-  --r-onsen-wq-info-val-size: 20px;
-  --r-onsen-wq-info-label-size: 12px;
-  --r-onsen-wq-efficacy-size: 15px;
 
   /* Onsen Guide */
   --r-onsen-guide-py: 80px;
@@ -89,8 +86,6 @@
     --r-onsen-wq-px: 60px;
     --r-onsen-wq-gap: 40px;
     --r-onsen-wq-title-size: 24px;
-    --r-onsen-wq-info-val-size: 18px;
-    --r-onsen-wq-efficacy-size: 14px;
 
     /* Onsen Guide */
     --r-onsen-guide-py: 60px;
@@ -143,8 +138,6 @@
     --r-onsen-wq-gap: 32px;
     --r-onsen-wq-title-size: 22px;
     --r-onsen-wq-title-ls: 3px;
-    --r-onsen-wq-info-val-size: 16px;
-    --r-onsen-wq-efficacy-size: 14px;
 
     /* Onsen Guide */
     --r-onsen-guide-py: 48px;
@@ -243,22 +236,25 @@
 }
 
 /* ===========================================
-   Water Quality Info Grid
-   PC: row | Tablet: row | Mobile: column
+   Water Quality Card Grid
+   PC: 4-col | Tablet: 2-col | Mobile: 1-col
    =========================================== */
 
 .r-onsen-wq-info-grid {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  gap: 64px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+@media (max-width: 1023px) {
+  .r-onsen-wq-info-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 767px) {
   .r-onsen-wq-info-grid {
-    flex-direction: column;
-    align-items: center;
-    gap: 32px;
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- Rewrote `WaterQualitySection` with correct data from .pen SSOT (previous data was hallucinated)
- Changed from 3-item flex row + separate efficacy section to 4-card CSS grid
- Cards: 源泉名(姥子温泉), 泉質(単純硫黄泉), 泉温(62.3℃), 効能(神経痛・筋肉痛等)
- Responsive grid: 4-col (PC) → 2-col (Tablet) → 1-col (Mobile)
- Updated tests to validate .pen SSOT values
- Cleaned up unused CSS variables (`--r-onsen-wq-info-val-size`, `--r-onsen-wq-info-label-size`, `--r-onsen-wq-efficacy-size`)

## Test plan
- [x] Verified PC layout (4-column grid) at 1440px
- [x] Verified Tablet layout (2x2 grid) at 768px
- [x] Verified Mobile layout (1-column) at 375px
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)