### PR TITLE
fix: align Experience & News pages with .pen SSOT

### DIFF
--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -119,7 +119,7 @@ export default async function NewsPage({ searchParams }: PageProps) {
             <section
               aria-label="お知らせページネーション"
               className="flex w-full items-center justify-center"
-              style={{ gap: 8, padding: '0 80px 72px 80px' }}
+              style={{ gap: 8, padding: '0 80px 60px 80px' }}
             >
               {Array.from({ length: totalPages }, (_, index) => {
                 const page = index + 1
@@ -134,12 +134,14 @@ export default async function NewsPage({ searchParams }: PageProps) {
                     href={href}
                     aria-current={isActive ? 'page' : undefined}
                     style={{
-                      minWidth: 32,
-                      textAlign: 'center',
+                      width: 40,
+                      height: 40,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
                       textDecoration: 'none',
-                      padding: '6px 10px',
                       borderRadius: 2,
-                      border: '1px solid var(--ryokan-light-gold)',
+                      border: isActive ? 'none' : '1px solid var(--ryokan-light-gold)',
                       backgroundColor: isActive ? 'var(--ryokan-dark)' : 'transparent',
                       color: isActive ? 'var(--ryokan-text-on-dark)' : 'var(--ryokan-dark)',
                       fontFamily: 'var(--font-body)',

--- a/src/components/experience/ConceptSection.tsx
+++ b/src/components/experience/ConceptSection.tsx
@@ -41,7 +41,7 @@ export function ConceptSection() {
             fontFamily: 'var(--font-body)',
             fontSize: 'var(--r-exp-concept-body)',
             fontWeight: 300,
-            color: 'var(--ryokan-secondary, #6B5D4F)',
+            color: 'var(--ryokan-muted, #4A4035)',
             letterSpacing: 'var(--r-exp-concept-body-ls)',
             lineHeight: 'var(--r-exp-concept-body-lh)',
             maxWidth: 'var(--r-exp-concept-body-w)',

--- a/src/components/experience/experience-responsive.css
+++ b/src/components/experience/experience-responsive.css
@@ -88,10 +88,10 @@
     --r-exp-timeline-line-h: 48px;
 
     /* Seasons Section */
-    --r-exp-seasons-pt: 48px;
-    --r-exp-seasons-px: 40px;
-    --r-exp-seasons-pb: 60px;
-    --r-exp-seasons-gap: 32px;
+    --r-exp-seasons-pt: 60px;
+    --r-exp-seasons-px: 60px;
+    --r-exp-seasons-pb: 80px;
+    --r-exp-seasons-gap: 40px;
     --r-exp-seasons-title: 24px;
     --r-exp-seasons-title-ls: 3px;
     --r-exp-seasons-card-img-h: 200px;
@@ -108,16 +108,16 @@
 
     /* Activities Section */
     --r-exp-act-py: 60px;
-    --r-exp-act-px: 60px;
-    --r-exp-act-gap: 40px;
+    --r-exp-act-px: 80px;
+    --r-exp-act-gap: 48px;
     --r-exp-act-title: 24px;
     --r-exp-act-title-ls: 3px;
     --r-exp-act-grid-gap: 24px;
 
     /* Links Section */
-    --r-exp-links-py: 32px;
-    --r-exp-links-px: 40px;
-    --r-exp-links-gap: 40px;
+    --r-exp-links-py: 40px;
+    --r-exp-links-px: 80px;
+    --r-exp-links-gap: 60px;
   }
 }
 
@@ -152,8 +152,8 @@
     /* Seasons Section */
     --r-exp-seasons-pt: 40px;
     --r-exp-seasons-px: 24px;
-    --r-exp-seasons-pb: 48px;
-    --r-exp-seasons-gap: 24px;
+    --r-exp-seasons-pb: 60px;
+    --r-exp-seasons-gap: 40px;
     --r-exp-seasons-title: 22px;
     --r-exp-seasons-title-ls: 2px;
     --r-exp-seasons-card-img-h: 200px;
@@ -169,17 +169,17 @@
     --r-exp-facility-card-gap: 12px;
 
     /* Activities Section */
-    --r-exp-act-py: 48px;
+    --r-exp-act-py: 60px;
     --r-exp-act-px: 24px;
-    --r-exp-act-gap: 32px;
+    --r-exp-act-gap: 48px;
     --r-exp-act-title: 22px;
     --r-exp-act-title-ls: 2px;
     --r-exp-act-grid-gap: 20px;
 
     /* Links Section */
-    --r-exp-links-py: 24px;
-    --r-exp-links-px: 24px;
-    --r-exp-links-gap: 24px;
+    --r-exp-links-py: 40px;
+    --r-exp-links-px: 80px;
+    --r-exp-links-gap: 60px;
   }
 }
 
@@ -297,11 +297,7 @@
   gap: var(--r-exp-links-gap);
 }
 
-@media (max-width: 767px) {
-  .r-exp-links-layout {
-    flex-direction: column;
-  }
-}
+/* .pen SSOT: links stay horizontal on all viewports */
 
 /* ===========================================
    Timeline Layout


### PR DESCRIPTION
## Summary
- Fix Experience page responsive CSS variables (Seasons, Activities, Links sections) to match .pen design SSOT values across tablet and mobile breakpoints
- Fix ConceptSection body text color (#6B5D4F -> #4A4035)
- Fix Experience Links mobile layout to stay horizontal per .pen SSOT
- Fix News page pagination bottom padding (72px -> 60px) and button sizing (40x40)

Closes #275, closes #276

## Changes
| Section | Viewport | What Changed |
|---------|----------|-------------|
| Seasons | Tablet | pt, px, pb, gap values |
| Seasons | Mobile | gap, pb values |
| Activities | Tablet | px, gap values |
| Activities | Mobile | py, gap values |
| Links | Tablet | py, px, gap values |
| Links | Mobile | py, px, gap, direction (column -> horizontal) |
| Concept | All | body text color |
| News pagination | PC | bottom padding, button size |

## Test plan
- [ ] Verify Experience page at 375px, 768px, 1024px, 1440px
- [ ] Verify Seasons section spacing matches .pen at all breakpoints
- [ ] Verify Activities section spacing matches .pen at all breakpoints
- [ ] Verify Experience Links horizontal layout on mobile
- [ ] Verify News pagination button sizing (40x40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)