### PR TITLE
fix: align Reservation, Contact, Privacy pages with .pen SSOT

### DIFF
--- a/src/components/ContactForm.module.css
+++ b/src/components/ContactForm.module.css
@@ -28,9 +28,9 @@
 .form select,
 .form textarea {
   width: 100%;
-  border: 1px solid rgba(139, 105, 20, 0.25);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border: 1px solid #D4C5A0;
+  border-radius: 2px;
+  padding: 12px 16px;
   font-size: 14px;
   color: var(--ryokan-dark);
   background: #fff;
@@ -83,12 +83,13 @@
 .submit {
   margin-top: 18px;
   border: none;
-  border-radius: 999px;
-  padding: 11px 22px;
+  border-radius: 2px;
+  padding: 18px 80px;
   background: var(--ryokan-gold);
   color: #fff;
-  font-size: 14px;
-  letter-spacing: 0.08em;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 4px;
   cursor: pointer;
 }
 

--- a/src/components/contact/ContactFormSection.tsx
+++ b/src/components/contact/ContactFormSection.tsx
@@ -21,7 +21,7 @@ export function ContactFormSection({ accessKey = '' }: ContactFormSectionProps) 
         style={{
           backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
           padding: 'var(--r-contact-form-inner-py) var(--r-contact-form-inner-px)',
-          gap: 24,
+          gap: 32,
           borderRadius: 4,
           border: '1px solid #D4C5A033',
         }}

--- a/src/components/privacy/PrivacyContentSection.tsx
+++ b/src/components/privacy/PrivacyContentSection.tsx
@@ -74,7 +74,7 @@ export function PrivacyContentSection() {
       className="flex w-full flex-col"
       style={{
         backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
-        padding: '80px 200px',
+        padding: 'var(--r-privacy-content-py) var(--r-privacy-content-px)',
         gap: 48,
       }}
     >

--- a/src/components/privacy/privacy-responsive.css
+++ b/src/components/privacy/privacy-responsive.css
@@ -1,0 +1,27 @@
+/* ===========================================
+   Privacy Page Responsive CSS Variables
+   Breakpoints: Mobile(<768) / Tablet(768-1023) / PC(>=1024)
+   =========================================== */
+
+/* --- PC (default, >= 1024px) --- */
+:root {
+  --r-privacy-content-py: 80px;
+  --r-privacy-content-px: 200px;
+  --r-privacy-updated-pt: 40px;
+}
+
+/* --- Tablet (768px - 1023px) --- */
+@media (max-width: 1023px) {
+  :root {
+    --r-privacy-content-py: 60px;
+    --r-privacy-content-px: 80px;
+  }
+}
+
+/* --- Mobile (< 768px) --- */
+@media (max-width: 767px) {
+  :root {
+    --r-privacy-content-py: 40px;
+    --r-privacy-content-px: 24px;
+  }
+}

--- a/src/components/reservation/BookingMethodsSection.tsx
+++ b/src/components/reservation/BookingMethodsSection.tsx
@@ -1,16 +1,18 @@
+import { Monitor, Phone, Globe } from 'lucide-react'
+
 const methods = [
   {
-    icon: 'monitor',
+    icon: Monitor,
     name: 'オンライン予約',
     description: 'Cal.comより24時間\nいつでもご予約いただけます',
   },
   {
-    icon: 'phone',
+    icon: Phone,
     name: 'お電話',
     description: '0460-83-XXXX\n受付時間 9:00〜20:00',
   },
   {
-    icon: 'globe',
+    icon: Globe,
     name: '旅行サイト',
     description: '一休.com等の\n旅行予約サイトからもご予約可能',
   },
@@ -51,23 +53,12 @@ export function BookingMethodsSection() {
               gap: 12,
             }}
           >
-            {/* Icon placeholder */}
-            <span
+            <method.icon
               aria-hidden="true"
-              style={{
-                width: 28,
-                height: 28,
-                color: 'var(--ryokan-gold, #8B6914)',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 28,
-              }}
-            >
-              {method.icon === 'monitor' && '🖥'}
-              {method.icon === 'phone' && '📞'}
-              {method.icon === 'globe' && '🌐'}
-            </span>
+              size={28}
+              color="var(--ryokan-gold, #8B6914)"
+              strokeWidth={1.5}
+            />
 
             <h3
               style={{


### PR DESCRIPTION
## Summary
- Replace emoji icons with lucide-react components (Monitor/Phone/Globe) in BookingMethodsSection per .pen icon_font specs (#280)
- Fix ContactForm input border-radius, border color, padding, and submit button styling to match .pen SSOT (#281)
- Fix ContactFormSection form container gap from 24 to 32
- Add privacy-responsive.css with responsive padding variables (PC: 200px, Tablet: 80px, Mobile: 24px) (#282)
- Update PrivacyContentSection to use CSS variables instead of hardcoded padding

## Test plan
- [x] `next build` succeeds
- [x] ESLint + TypeScript check pass (pre-push hooks)
- [x] Playwright visual verification at 1440px, 768px, 375px for all 3 pages
- [x] Reservation: lucide icons render correctly in booking methods section
- [x] Contact: form inputs have correct border-radius (2px) and submit button styling
- [x] Privacy: responsive padding adapts across breakpoints

Closes #280, #281, #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)