### PR TITLE
fix: audit legal and sitemap pages against .pen SSOT

### DIFF
--- a/src/app/legal/__tests__/page.test.tsx
+++ b/src/app/legal/__tests__/page.test.tsx
@@ -29,6 +29,10 @@ vi.mock('@/components/shared/Breadcrumb/Breadcrumb', () => ({
   ),
 }))
 
+vi.mock('@/components/shared/CTASection/CTASection', () => ({
+  CTASection: () => <div data-testid="cta-section">CTA</div>,
+}))
+
 describe('LegalPage', () => {
   it('renders the page with ryokan-page class', () => {
     const { container } = render(<LegalPage />)
@@ -77,10 +81,9 @@ describe('LegalPage', () => {
     ).toBeInTheDocument()
   })
 
-  it('does not render a CTASection (legal pages skip CTA)', () => {
-    const { container } = render(<LegalPage />)
-    // CTA section would have a background image wrapper -- we ensure no CTA exists
-    expect(container.querySelector('[data-testid="cta-section"]')).not.toBeInTheDocument()
+  it('renders CTASection per .pen SSOT (between content and footer)', () => {
+    render(<LegalPage />)
+    expect(screen.getByTestId('cta-section')).toBeInTheDocument()
   })
 
   it('renders page elements in correct order: Header, main content, Footer', () => {

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -2,6 +2,7 @@ import { Header } from '@/components/shared/Header/Header'
 import { PageHero } from '@/components/shared/PageHero/PageHero'
 import { Breadcrumb } from '@/components/shared/Breadcrumb/Breadcrumb'
 import { LegalContentSection } from '@/components/legal/LegalContentSection'
+import { CTASection } from '@/components/shared/CTASection/CTASection'
 import { Footer } from '@/components/shared/Footer/Footer'
 
 export default function LegalPage() {
@@ -20,6 +21,7 @@ export default function LegalPage() {
           ]}
         />
         <LegalContentSection />
+        <CTASection />
       </main>
       <Footer />
     </div>

--- a/src/app/sitemap/page.tsx
+++ b/src/app/sitemap/page.tsx
@@ -36,28 +36,33 @@ export default function SitemapPage() {
         <section
           aria-label="サイト内ページ一覧"
           style={{
-            maxWidth: 960,
-            margin: '0 auto',
-            padding: '56px 24px 80px',
+            backgroundColor: 'var(--ryokan-bg, #FAF8F3)',
+            padding: 'var(--r-legal-py, 80px) var(--r-legal-px, 200px)',
           }}
         >
           <ul
+            className="sitemap-link-list"
             style={{
               listStyle: 'none',
               margin: 0,
               padding: 0,
               display: 'grid',
-              gap: 12,
+              gap: 16,
             }}
           >
             {SITEMAP_LINKS.map((item) => (
               <li key={item.href}>
                 <Link
                   href={item.href}
+                  className="sitemap-link"
                   style={{
-                    color: 'var(--ryokan-darkest)',
+                    color: 'var(--ryokan-dark, #2C2418)',
                     textDecoration: 'none',
                     fontFamily: 'var(--font-body)',
+                    fontSize: 14,
+                    fontWeight: 300,
+                    lineHeight: 2,
+                    letterSpacing: 1,
                   }}
                 >
                   {item.label}

--- a/src/lib/css/ryokan-responsive.css
+++ b/src/lib/css/ryokan-responsive.css
@@ -605,7 +605,7 @@
 @media (max-width: 767px) {
   .r-legal-info-row {
     flex-direction: column;
-    gap: 4px;
+    gap: 8px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add missing CTA section to legal page per .pen SSOT (penId: 4sqVI existed on all 3 viewports but code omitted it)
- Fix mobile info row gap from 4px to 8px to match the dominant .pen value (5 of 6 rows use gap: 8)
- Improve sitemap page styling for visual consistency: background color, responsive padding via existing CSS variables, proper font sizing

## Files Changed
- `src/app/legal/page.tsx` - Added `<CTASection />` import and usage
- `src/app/legal/__tests__/page.test.tsx` - Updated test to expect CTA (was incorrectly asserting its absence), added CTASection mock
- `src/app/sitemap/page.tsx` - Added background color, responsive padding, font styling for consistency
- `src/lib/css/ryokan-responsive.css` - Changed mobile `.r-legal-info-row` gap from 4px to 8px

## Audit Findings
| Issue | Severity | Fix |
|-------|----------|-----|
| Missing CTA section on legal page | High (SSOT mismatch) | Added CTASection |
| Mobile info row gap 4px vs 8px | Low (.pen inconsistency) | Changed to 8px |
| Sitemap page missing background/styling | Medium (no SSOT) | Added ryokan theme styles |

## Test Plan
- [x] TypeScript type check passes
- [x] All 40 legal page tests pass (8 page + 32 component)
- [x] ESLint passes with 0 warnings
- [x] Visual verification at 375px, 500px, 768px, 900px, 1100px, 1440px for legal page
- [x] Visual verification at 375px, 768px, 1440px for sitemap page
- [x] No layout breakage at intermediate widths

Fixes #284, #285, #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)